### PR TITLE
async effects get prior task and interupt event

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,7 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+
 
 
 v1.0.0

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,21 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
+**Fixed**
 
+- :issue:`956` - Async effects now accept two arguments - the prior effect's
+  ``asyncio.Task`` (or ``None``) and an interupt ``asyncio.Event``. The prior effect's
+  task allows effect authors to await or cancel it to ensure that it has completed
+  before executing the next effect. The interupt event is used to signal that the effect
+  should stop and clean up any resources it may have allocated. This is useful for
+  effects that may be long running and need to be stopped when the component is
+  unmounted.
+
+**Deprecated**
+
+- :pull:`957` - Async effects that do not accept any arguments are now deprecated and
+  will be disallowed in a future release. All async effects should accept two
+  arguments - the prior effect's task and an interupt event.
 
 
 v1.0.0

--- a/docs/source/reference/_examples/simple_dashboard.py
+++ b/docs/source/reference/_examples/simple_dashboard.py
@@ -97,7 +97,7 @@ def use_interval(rate):
         await asyncio.sleep(rate - (time.time() - usage_time.current))
         usage_time.current = time.time()
 
-    return asyncio.ensure_future(interval())
+    return asyncio.create_task(interval())
 
 
 reactpy.run(RandomWalk)

--- a/docs/source/reference/_examples/snake_game.py
+++ b/docs/source/reference/_examples/snake_game.py
@@ -135,7 +135,7 @@ def use_interval(rate):
         await asyncio.sleep(rate - (time.time() - usage_time.current))
         usage_time.current = time.time()
 
-    return asyncio.ensure_future(interval())
+    return asyncio.create_task(interval())
 
 
 def create_grid(grid_size, block_scale):

--- a/src/reactpy/backend/flask.py
+++ b/src/reactpy/backend/flask.py
@@ -242,7 +242,7 @@ def _dispatch_in_thread(
                 async_recv_queue.get,
             )
 
-        main_future = asyncio.ensure_future(main(), loop=loop)
+        main_future = asyncio.create_task(main(), loop=loop)
 
         dispatch_thread_info_ref.current = _DispatcherThreadInfo(
             dispatch_loop=loop,

--- a/src/reactpy/backend/tornado.py
+++ b/src/reactpy/backend/tornado.py
@@ -190,7 +190,7 @@ class ModelStreamHandler(WebSocketHandler):
             return json.loads(await message_queue.get())
 
         self._message_queue = message_queue
-        self._dispatch_future = asyncio.ensure_future(
+        self._dispatch_future = asyncio.create_task(
             serve_layout(
                 Layout(
                     ConnectionContext(

--- a/src/reactpy/core/types.py
+++ b/src/reactpy/core/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from collections import namedtuple
 from collections.abc import Sequence
@@ -7,6 +8,7 @@ from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Generic,
     Mapping,
@@ -233,3 +235,12 @@ class LayoutEventMessage(TypedDict):
     """The ID of the event handler."""
     data: Sequence[Any]
     """A list of event data passed to the event handler."""
+
+
+SyncEffect: TypeAlias = "Callable[[], None | Callable[[], None]]"
+"""A synchronous function which can be run by the :func:`use_effect` hook"""
+
+AsyncEffect: TypeAlias = (
+    "Callable[[asyncio.Task | None, asyncio.Event], Awaitable[None]]"
+)
+"""A asynchronous function which can be run by the :func:`use_effect` hook"""

--- a/tests/test_core/test_serve.py
+++ b/tests/test_core/test_serve.py
@@ -122,7 +122,7 @@ async def test_dispatcher_handles_more_than_one_event_at_a_time():
     send_queue = asyncio.Queue()
     recv_queue = asyncio.Queue()
 
-    asyncio.ensure_future(
+    asyncio.create_task(
         serve_layout(
             reactpy.Layout(ComponentWithTwoEventHandlers()),
             send_queue.put,


### PR DESCRIPTION
async effects without arguments are now deprecated

## Checklist

Please update this checklist as you complete each item:

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
- [ ] GitHub Issues which may be closed by this Pull Request have been linked.
