### PR TITLE
Fix Tornado Backend

### DIFF
--- a/src/reactpy/backend/tornado.py
+++ b/src/reactpy/backend/tornado.py
@@ -196,7 +196,7 @@ class ModelStreamHandler(WebSocketHandler):
                     ConnectionContext(
                         self._component_constructor(),
                         value=Connection(
-                            scope=WSGIContainer.environ(self.request),
+                            scope=_FAKE_WSGI_CONTAINER.environ(self.request),
                             location=Location(
                                 pathname=f"/{path[len(self._url_prefix):]}",
                                 search=(
@@ -222,3 +222,10 @@ class ModelStreamHandler(WebSocketHandler):
     def on_close(self) -> None:
         if not self._dispatch_future.done():
             self._dispatch_future.cancel()
+
+
+# The interface for WSGIContainer.environ changed in Tornado version 6.3 from
+# a staticmethod to an instance method. Since we're not that concerned with
+# the details of the WSGI app itself, we can just use a fake one.
+# see: https://github.com/tornadoweb/tornado/pull/3231#issuecomment-1518957578
+_FAKE_WSGI_CONTAINER = WSGIContainer(lambda *a, **kw: iter([]))


### PR DESCRIPTION
## Issues

`WSGIContainer.environ` changed from a staticmethod to an instance method.

## Summary

Since we don't actually need a WSGI app and just want the ability to convert Tornado requests to an environ dict we create a dummy `WSGIContainer` and call its environ method. Thankfully, the only thing that seems to depend on the `WSGIContainer` itself is threading info according to the [diff](https://github.com/tornadoweb/tornado/pull/3231/commits/c34c0f32a7efbf1577b1ce4610312843502912bd#diff-81098061e58a7ca958f743e49f767186b1d5a330bbcb3d977cb58fce5100e331R235).

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
