### PR TITLE
fix poetry docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,9 +8,16 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
 RUN apt-get install -yq nodejs build-essential
 RUN npm install -g npm@8.5.0
 
-# Install Pipx
-# ------------
-RUN pip install pipx
+# Install Poetry
+# --------------
+RUN pip install poetry
+
+# Create/Activate Python Venv
+# ---------------------------
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install --upgrade pip
 
 # Copy Files
 # ----------
@@ -22,12 +29,12 @@ COPY branding ./branding
 # Install and Build Docs
 # ----------------------
 WORKDIR /app/docs
-RUN pipx run poetry install
-RUN pipx run poetry run sphinx-build -v -W -b html source build
+RUN poetry install
+RUN sphinx-build -v -W -b html source build
 
 # Define Entrypoint
 # -----------------
 ENV PORT 5000
 ENV REACTPY_DEBUG_MODE=1
 ENV REACTPY_CHECK_VDOM_SPEC=0
-CMD pipx run poetry run python main.py
+CMD python main.py


### PR DESCRIPTION
Poetry docs are broken:

```
2023-06-03T22:12:30.486911+00:00 heroku[web.1]: Starting process with command `/bin/sh -c pipx\ run\ poetry\ run\ python\ main.py`
2023-06-03T22:12:32.452922+00:00 app[web.1]: creating virtual environment...
2023-06-03T22:12:32.493175+00:00 app[web.1]: creating shared libraries...
2023-06-03T22:12:36.152850+00:00 app[web.1]: upgrading shared libraries...
2023-06-03T22:12:44.947651+00:00 app[web.1]: installing poetry...
2023-06-03T22:12:56.226991+00:00 app[web.1]: Creating virtualenv docs-DoOuTdRN-py3.9 in /app/docs/.cache/pypoetry/virtualenvs
2023-06-03T22:12:57.064521+00:00 app[web.1]: Traceback (most recent call last):
2023-06-03T22:12:57.064523+00:00 app[web.1]:   File "/app/docs/main.py", line 3, in <module>
2023-06-03T22:12:57.064561+00:00 app[web.1]:     from docs_app import dev, prod
2023-06-03T22:12:57.064561+00:00 app[web.1]:   File "/app/docs/docs_app/dev.py", line 7, in <module>
2023-06-03T22:12:57.064598+00:00 app[web.1]:     from sphinx_autobuild.cli import (
2023-06-03T22:12:57.064604+00:00 app[web.1]: ModuleNotFoundError: No module named 'sphinx_autobuild'
```

Somehow the venv created by Poetry via pipx was not preserved.