### PR TITLE
Fix typos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 We provide two main ways to run the docs. Both use
 [`nox`](https://pypi.org/project/nox/):
 
-- `nox -s docs` - displayes the docs and rebuilds when files are modified.
+- `nox -s docs` - displays the docs and rebuilds when files are modified.
 - `nox -s docs-in-docker` - builds a docker image and runs the docs from there.
 
 If any changes to the core of the documentation are made (i.e. to non-`*.rst` files),

--- a/docs/source/_custom_js/src/index.js
+++ b/docs/source/_custom_js/src/index.js
@@ -86,7 +86,7 @@ function triggerIfInViewport(element, callback) {
     },
     {
       root: null,
-      threshold: 0.1, // set offset 0.1 means trigger if atleast 10% of element in viewport
+      threshold: 0.1, // set offset 0.1 means trigger if at least 10% of element in viewport
     },
   );
 

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -62,7 +62,7 @@ v1.0.0-a4
 
 **Deprecated**
 
-- :pull:`919` - Declaration of keys via keywork arguments in standard elements. A script
+- :pull:`919` - Declaration of keys via keyword arguments in standard elements. A script
   has been added to automatically convert old usages where possible.
 
 
@@ -590,7 +590,7 @@ v0.35.2
 This release includes several bug fixes. The most significant of which is the ability to
 change the type of an element in the try (i.e. to and from being a component) without
 getting an error. Originally the errors were introduced because it was though changing
-element type would not be desireable. This was not the case though - swapping types
+element type would not be desirable. This was not the case though - swapping types
 turns out to be quite common and useful.
 
 **Closed Issues**

--- a/docs/source/guides/adding-interactivity/components-with-state/_examples/adding_state_variable/data.json
+++ b/docs/source/guides/adding-interactivity/components-with-state/_examples/adding_state_variable/data.json
@@ -44,7 +44,7 @@
   {
     "name": "Terracotta Army",
     "artist": "Unknown Artist",
-    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consited of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
+    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
     "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg/1920px-2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg",
     "alt": "12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor."
   },

--- a/docs/source/guides/adding-interactivity/components-with-state/_examples/isolated_state/data.json
+++ b/docs/source/guides/adding-interactivity/components-with-state/_examples/isolated_state/data.json
@@ -44,7 +44,7 @@
   {
     "name": "Terracotta Army",
     "artist": "Unknown Artist",
-    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consited of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
+    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
     "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg/1920px-2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg",
     "alt": "12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor."
   },

--- a/docs/source/guides/adding-interactivity/components-with-state/_examples/multiple_state_variables/data.json
+++ b/docs/source/guides/adding-interactivity/components-with-state/_examples/multiple_state_variables/data.json
@@ -44,7 +44,7 @@
   {
     "name": "Terracotta Army",
     "artist": "Unknown Artist",
-    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consited of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
+    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
     "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg/1920px-2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg",
     "alt": "12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor."
   },

--- a/docs/source/guides/adding-interactivity/components-with-state/_examples/when_variables_are_not_enough/data.json
+++ b/docs/source/guides/adding-interactivity/components-with-state/_examples/when_variables_are_not_enough/data.json
@@ -44,7 +44,7 @@
   {
     "name": "Terracotta Army",
     "artist": "Unknown Artist",
-    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consited of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
+    "description": "The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.",
     "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg/1920px-2015-09-22-081415_-_Terrakotta-Armee%2C_Grosse_Halle.jpg",
     "alt": "12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor."
   },

--- a/docs/source/guides/adding-interactivity/dangers-of-mutability/index.rst
+++ b/docs/source/guides/adding-interactivity/dangers-of-mutability/index.rst
@@ -531,7 +531,7 @@ Removing Set Items
             s.difference_update(values)
             s -= values  # "in-place" operators mutate!
 
-            s.symetric_difference_update(values)
+            s.symmetric_difference_update(values)
             s ^= values  # "in-place" operators mutate!
 
             s.intersection_update(values)
@@ -547,7 +547,7 @@ Removing Set Items
             s.difference(values)
             s - values
 
-            s.symetric_difference(values)
+            s.symmetric_difference(values)
             s ^ values
 
             s.intersection(values)

--- a/docs/source/guides/adding-interactivity/index.rst
+++ b/docs/source/guides/adding-interactivity/index.rst
@@ -111,7 +111,7 @@ Section 3: State as a Snapshot
 ------------------------------
 
 As we :ref:`learned earlier <Components with State>`, state setters behave a little
-differently than you might exepct at first glance. Instead of updating your current
+differently than you might expect at first glance. Instead of updating your current
 handle on the setter's corresponding variable, it schedules a re-render of the component
 which owns the state.
 
@@ -133,7 +133,7 @@ actually sent?
 .. reactpy:: state-as-a-snapshot/_examples/print_chat_message
 
 As it turns out, changing the message recipient after pressing send does not change
-where the message ulitmately goes. However, one could imagine a bug where the recipient
+where the message ultimately goes. However, one could imagine a bug where the recipient
 of a message is determined at the time the message is sent rather than at the time the
 "Send" button it clicked. Thus changing the recipient after pressing send would change
 where the message got sent.

--- a/docs/source/guides/adding-interactivity/multiple-state-updates/index.rst
+++ b/docs/source/guides/adding-interactivity/multiple-state-updates/index.rst
@@ -10,7 +10,7 @@ Batched Updates
 ---------------
 
 As we learned :ref:`previously <state as a snapshot>`, state variables remain fixed
-inside each render as if state were a snapshot taken at the begining of each render.
+inside each render as if state were a snapshot taken at the beginning of each render.
 This is why, in the example below, even though it might seem like clicking the
 "Increment" button would cause the ``number`` to increase by ``3``, it only does by
 ``1``:
@@ -22,7 +22,7 @@ the event handler is not an ``async`` function), ReactPy waits until all the cod
 event handler has run before processing state and starting the next render. Thus, it's
 the last call to a given state setter that matters. In the example below, even though we
 set the color of the button to ``"orange"`` and then ``"pink"`` before ``"blue"``,
-the color does not quickly flash orange and pink before blue - it alway remains blue:
+the color does not quickly flash orange and pink before blue - it always remains blue:
 
 .. reactpy:: _examples/set_color_3_times
 

--- a/docs/source/guides/adding-interactivity/responding-to-events/_examples/stop_event_propagation.py
+++ b/docs/source/guides/adding-interactivity/responding-to-events/_examples/stop_event_propagation.py
@@ -30,7 +30,7 @@ def DivInDiv():
     return html.div(
         html.button(
             {"on_click": lambda event: set_stop_propagatation(not stop_propagatation)},
-            "Toggle Propogation",
+            "Toggle Propagation",
         ),
         html.pre(f"Will propagate: {not stop_propagatation}"),
         html.pre(f"Inner click count: {inner_count}"),

--- a/docs/source/guides/adding-interactivity/responding-to-events/index.rst
+++ b/docs/source/guides/adding-interactivity/responding-to-events/index.rst
@@ -131,13 +131,13 @@ Unfortunately this means you cannot conditionally prevent default behavior in re
 to event data without writing :ref:`Custom Javascript Components`.
 
 
-Stop Event Propogation
+Stop Event Propagation
 ......................
 
 Similarly to :ref:`preventing default behavior <Preventing Default Event Actions>`, you
 can use the :func:`~reactpy.core.events.event` decorator to prevent events originating in a
 child element from propagating to parent elements by setting ``stop_propagation``. In
-the example below we place a red ``div`` inside a parent blue ``div``. When propogation
+the example below we place a red ``div`` inside a parent blue ``div``. When propagation
 is turned on, clicking the red element will cause the handler for the outer blue one to
 trigger. Conversely, when it's off, only the handler for the red element will trigger.
 

--- a/docs/source/guides/adding-interactivity/state-as-a-snapshot/index.rst
+++ b/docs/source/guides/adding-interactivity/state-as-a-snapshot/index.rst
@@ -17,7 +17,7 @@ version of the view rather then mutating the existing one.
 
 Given this, when ReactPy "renders" something, it's as if ReactPy has taken a snapshot of the
 UI where all the event handlers, local variables and the view itself were calculated
-using what state was present at the time of that render. Then, when user iteractions
+using what state was present at the time of that render. Then, when user interactions
 trigger state setters, ReactPy is made away of the newly set state and schedules a
 re-render. When this subsequent renders occurs it performs all the same calculations as
 before, but with this new state.
@@ -70,7 +70,7 @@ Even though, we called ``set_count`` three times with what might have seemed lik
 different values, every time we were actually just doing ``set_count(1)`` on each call.
 Only after the event handler returns will ReactPy actually perform the next render where
 count is ``1``. When it does, ``number`` will be ``1`` and we'll be able to perform the
-same subtitution as before to see what the next number will be after we click
+same substitution as before to see what the next number will be after we click
 "Increment":
 
 .. code-block::
@@ -89,7 +89,7 @@ to reason about what should happen in the example below. What will be printed wh
 
 .. reactpy:: _examples/print_count_after_set
 
-If we use the same subtitution trick we saw before, we can rewrite these lines:
+If we use the same substitution trick we saw before, we can rewrite these lines:
 
 .. code-block::
 

--- a/docs/source/guides/creating-interfaces/html-with-reactpy/index.rst
+++ b/docs/source/guides/creating-interfaces/html-with-reactpy/index.rst
@@ -99,7 +99,7 @@ In ReactPy we add these attributes to elements using a dictionary:
 
 .. raw:: html
 
-    <!-- no tabindex since that would ruin accesibility of the page -->
+    <!-- no tabindex since that would ruin accessibility of the page -->
     <img
         src="https://picsum.photos/id/237/500/300"
         class="img-fluid"

--- a/docs/source/guides/escape-hatches/distributing-javascript.rst
+++ b/docs/source/guides/escape-hatches/distributing-javascript.rst
@@ -174,7 +174,7 @@ loaded with :func:`~reactpy.web.module.export`.
         # unique since it must share a namespace with all other javascript packages.
         name="YOUR-PACKAGE-NAME",
         file=_BUNDLE_PATH,
-        # What to temporarilly display while the module is being loaded
+        # What to temporarily display while the module is being loaded
         fallback="Loading...",
     )
 

--- a/docs/source/guides/getting-started/_examples/debug_error_example.py
+++ b/docs/source/guides/getting-started/_examples/debug_error_example.py
@@ -8,7 +8,7 @@ def App():
 
 @component
 def GoodComponent():
-    return html.p("This component rendered successfuly")
+    return html.p("This component rendered successfully")
 
 
 @component

--- a/docs/source/guides/understanding-reactpy/representing-html.rst
+++ b/docs/source/guides/understanding-reactpy/representing-html.rst
@@ -7,7 +7,7 @@ Representing HTML 🚧
 
     Under construction 🚧
 
-We've already discussed how to contruct HTML with ReactPy in a :ref:`previous section <HTML
+We've already discussed how to construct HTML with ReactPy in a :ref:`previous section <HTML
 with ReactPy>`, but we skimmed over the question of the data structure we use to represent
 it. Let's reconsider the examples from before - on the top is some HTML and on the
 bottom is the corresponding code to create it in ReactPy:

--- a/docs/source/reference/_static/vdom-json-schema.json
+++ b/docs/source/reference/_static/vdom-json-schema.json
@@ -61,7 +61,7 @@
       },
       "type": ["object", "string"]
     },
-    "eventHander": {
+    "eventHandler": {
       "properties": {
         "preventDefault": {
           "type": "boolean"

--- a/docs/source/reference/html-attributes.rst
+++ b/docs/source/reference/html-attributes.rst
@@ -11,7 +11,7 @@ words. For example, ``tabindex`` and ``margin-left`` become ``tab_index`` and
 ``margin_left`` respectively.
 
 
-Noteable Attributes
+Notable Attributes
 -------------------
 
 Some attributes in ReactPy are renamed, have special meaning, or are used differently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [project]
 name = "scripts"
 version = "0.0.0"
-description = "Scripts for managing the ReactPy respository"
+description = "Scripts for managing the ReactPy repository"
 
 # --- Hatch ----------------------------------------------------------------------------
 

--- a/src/js/packages/event-to-object/tests/event-to-object.test.ts
+++ b/src/js/packages/event-to-object/tests/event-to-object.test.ts
@@ -57,7 +57,7 @@ const simpleTestCases: SimpleTestCase<any>[] = [
   },
   {
     types: ["copy", "cut", "paste"],
-    description: "clipboad event",
+    description: "clipboard event",
     givenEventType: window.ClipboardEvent,
     expectedConversion: { clipboardData: null },
   },

--- a/src/py/reactpy/reactpy/_console/ast_utils.py
+++ b/src/py/reactpy/reactpy/_console/ast_utils.py
@@ -41,7 +41,7 @@ def rewrite_changed_nodes(
             msg = "Failed to change code"
             raise RuntimeError(msg)
 
-    # check if an nodes to rewrite contain eachother, pick outermost nodes
+    # check if an nodes to rewrite contain each other, pick outermost nodes
     current_outermost_node, *sorted_nodes_to_unparse = sorted(
         nodes_to_unparse, key=lambda n: n.lineno
     )

--- a/src/py/reactpy/reactpy/_console/rewrite_keys.py
+++ b/src/py/reactpy/reactpy/_console/rewrite_keys.py
@@ -40,7 +40,7 @@ def rewrite_keys(paths: list[str]) -> None:
     recommend running your code formatter like Black against your code after executing
     this command.
 
-    Additionally, We are unable to perserve the location of comments that lie within any
+    Additionally, We are unable to preserve the location of comments that lie within any
     rewritten code. This command will place the comments in the code it plans to rewrite
     just above its changes. As such it requires manual intervention to put those
     comments back in their original location.

--- a/src/py/reactpy/reactpy/backend/flask.py
+++ b/src/py/reactpy/reactpy/backend/flask.py
@@ -106,7 +106,7 @@ async def serve_development_app(
     try:
         await stopped.wait()
     finally:
-        # we may have exitted because this task was cancelled
+        # we may have exited because this task was cancelled
         server.current.shutdown()
         # the thread should eventually join
         thread.join(timeout=3)

--- a/src/py/reactpy/reactpy/config.py
+++ b/src/py/reactpy/reactpy/config.py
@@ -1,6 +1,6 @@
 """
 ReactPy provides a series of configuration options that can be set using environment
-variables or, for those which allow it, a programatic interface.
+variables or, for those which allow it, a programmatic interface.
 """
 
 from pathlib import Path
@@ -49,7 +49,7 @@ REACTPY_WEB_MODULES_DIR = _Option(
 
 This directory **MUST** be treated as a black box. Downstream applications **MUST NOT**
 assume anything about the structure of this directory see :mod:`reactpy.web.module` for a
-set of publically available APIs for working with the client.
+set of publicly available APIs for working with the client.
 """
 
 REACTPY_TESTING_DEFAULT_TIMEOUT = _Option(

--- a/src/py/reactpy/reactpy/core/events.py
+++ b/src/py/reactpy/reactpy/core/events.py
@@ -44,7 +44,7 @@ def event(
         element = reactpy.html.button({"onClick": my_callback})
 
     You may want the ability to prevent the default action associated with the event
-    from taking place, or stoping the event from propagating up the DOM. This decorator
+    from taking place, or stopping the event from propagating up the DOM. This decorator
     allows you to add that functionality to your callbacks.
 
     .. code-block:: python
@@ -191,7 +191,7 @@ def merge_event_handlers(
             or handler.prevent_default != prevent_default
             or handler.target != target
         ):
-            msg = "Cannot merge handlers - 'stop_propagation', 'prevent_default' or 'target' mistmatch."
+            msg = "Cannot merge handlers - 'stop_propagation', 'prevent_default' or 'target' mismatch."
             raise ValueError(msg)
 
     return EventHandler(

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -341,7 +341,7 @@ def use_callback(
         function:
             The function whose identity will be preserved
         dependencies:
-            Dependencies of the callback. The identity the ``function`` will be udpated
+            Dependencies of the callback. The identity the ``function`` will be updated
             if the identity of any value in the given sequence changes (i.e. their
             :func:`id` is different). By default these are inferred based on local
             variables that are referenced by the given function.
@@ -573,7 +573,7 @@ class LifeCycleHook:
             # given render have been completed.
             hook.affect_layout_did_render()
 
-            # Typically an event occurs and a new render is scheduled, thus begining
+            # Typically an event occurs and a new render is scheduled, thus beginning
             # the render cycle anew.
             hook.schedule_render()
 
@@ -626,7 +626,7 @@ class LifeCycleHook:
 
     def use_state(self, function: Callable[[], _Type]) -> _Type:
         if not self._rendered_atleast_once:
-            # since we're not intialized yet we're just appending state
+            # since we're not initialized yet we're just appending state
             result = function()
             self._state += (result,)
         else:
@@ -636,7 +636,7 @@ class LifeCycleHook:
         return result
 
     def add_effect(self, effect_type: EffectType, function: Callable[[], None]) -> None:
-        """Trigger a function on the occurance of the given effect type"""
+        """Trigger a function on the occurrence of the given effect type"""
         self._event_effects[effect_type].append(function)
 
     def set_context_provider(self, provider: ContextProvider[Any]) -> None:

--- a/src/py/reactpy/reactpy/core/layout.py
+++ b/src/py/reactpy/reactpy/core/layout.py
@@ -568,7 +568,7 @@ class _ModelState:
         """The actual model of the element"""
 
         self.patch_path = patch_path
-        """A "/" delimitted path to the element within the greater layout"""
+        """A "/" delimited path to the element within the greater layout"""
 
         self.children_by_key = children_by_key
         """Child model states indexed by their unique keys"""

--- a/src/py/reactpy/reactpy/core/types.py
+++ b/src/py/reactpy/reactpy/core/types.py
@@ -187,7 +187,7 @@ class EventHandlerType(Protocol):
     """Typically left as ``None`` except when a static target is useful.
 
     When testing, it may be useful to specify a static target ID so events can be
-    triggered programatically.
+    triggered programmatically.
 
     .. note::
 

--- a/src/py/reactpy/reactpy/core/vdom.py
+++ b/src/py/reactpy/reactpy/core/vdom.py
@@ -58,10 +58,10 @@ VDOM_JSON_SCHEMA = {
         "elementEventHandlers": {
             "type": "object",
             "patternProperties": {
-                ".*": {"$ref": "#/definitions/eventHander"},
+                ".*": {"$ref": "#/definitions/eventHandler"},
             },
         },
-        "eventHander": {
+        "eventHandler": {
             "type": "object",
             "properties": {
                 "target": {"type": "string"},
@@ -152,7 +152,7 @@ def vdom(
             iterables of children. The attribute mapping **must** precede the children,
             or children which will be merged into their respective parts of the model.
         key:
-            A string idicating the identity of a particular element. This is significant
+            A string indicating the identity of a particular element. This is significant
             to preserve event handlers across updates - without a key, a re-render would
             cause these handlers to be deleted, but with a key, they would be redirected
             to any newly defined handlers.

--- a/src/py/reactpy/reactpy/html.py
+++ b/src/py/reactpy/reactpy/html.py
@@ -4,7 +4,7 @@
 
 - :func:`_`
 
-**Dcument metadata**
+**Document metadata**
 
 - :func:`base`
 - :func:`head`
@@ -309,7 +309,7 @@ def _fragment(
 _ = custom_vdom_constructor(_fragment)
 
 
-# Dcument metadata
+# Document metadata
 base = make_vdom_constructor("base")
 head = make_vdom_constructor("head")
 link = make_vdom_constructor("link")

--- a/src/py/reactpy/reactpy/testing/backend.py
+++ b/src/py/reactpy/reactpy/testing/backend.py
@@ -167,7 +167,7 @@ def _hotswap(update_on_change: bool = False) -> tuple[_MountFunc, ComponentConst
     long as you set things up ahead of time.
 
     Parameters:
-        update_on_change: Whether or not all views of the layout should be udpated on a swap.
+        update_on_change: Whether or not all views of the layout should be updated on a swap.
 
     Example:
         .. code-block:: python

--- a/src/py/reactpy/reactpy/utils.py
+++ b/src/py/reactpy/reactpy/utils.py
@@ -232,7 +232,7 @@ def _generate_vdom_children(
 ) -> list[VdomDict | str]:
     """Generates a list of VDOM children from an lxml node.
 
-    Inserts inner text and/or tail text inbetween VDOM children, if necessary.
+    Inserts inner text and/or tail text in between VDOM children, if necessary.
     """
     return (  # Get the inner text of the current node
         [node.text] if node.text else []

--- a/src/py/reactpy/reactpy/web/module.py
+++ b/src/py/reactpy/reactpy/web/module.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 SourceType = NewType("SourceType", str)
 
 NAME_SOURCE = SourceType("NAME")
-"""A named souce - usually a Javascript package name"""
+"""A named source - usually a Javascript package name"""
 
 URL_SOURCE = SourceType("URL")
 """A source loaded from a URL, usually a CDN"""
@@ -44,14 +44,14 @@ def module_from_url(
             Where the javascript module will be loaded from which conforms to the
             interface for :ref:`Custom Javascript Components`
         fallback:
-            What to temporarilly display while the module is being loaded.
+            What to temporarily display while the module is being loaded.
         resolve_imports:
             Whether to try and find all the named exports of this module.
         resolve_exports_depth:
             How deeply to search for those exports.
         unmount_before_update:
             Cause the component to be unmounted before each update. This option should
-            only be used if the imported package failes to re-render when props change.
+            only be used if the imported package fails to re-render when props change.
             Using this option has negative performance consequences since all DOM
             elements must be changed on each render. See :issue:`461` for more info.
     """
@@ -110,14 +110,14 @@ def module_from_template(
         cdn:
             Where the package should be loaded from. The CDN must distribute ESM modules
         fallback:
-            What to temporarilly display while the module is being loaded.
+            What to temporarily display while the module is being loaded.
         resolve_imports:
             Whether to try and find all the named exports of this module.
         resolve_exports_depth:
             How deeply to search for those exports.
         unmount_before_update:
             Cause the component to be unmounted before each update. This option should
-            only be used if the imported package failes to re-render when props change.
+            only be used if the imported package fails to re-render when props change.
             Using this option has negative performance consequences since all DOM
             elements must be changed on each render. See :issue:`461` for more info.
     """
@@ -174,14 +174,14 @@ def module_from_file(
         file:
             The file from which the content of the web module will be created.
         fallback:
-            What to temporarilly display while the module is being loaded.
+            What to temporarily display while the module is being loaded.
         resolve_imports:
             Whether to try and find all the named exports of this module.
         resolve_exports_depth:
             How deeply to search for those exports.
         unmount_before_update:
             Cause the component to be unmounted before each update. This option should
-            only be used if the imported package failes to re-render when props change.
+            only be used if the imported package fails to re-render when props change.
             Using this option has negative performance consequences since all DOM
             elements must be changed on each render. See :issue:`461` for more info.
         symlink:
@@ -255,14 +255,14 @@ def module_from_string(
         content:
             The contents of the web module
         fallback:
-            What to temporarilly display while the module is being loaded.
+            What to temporarily display while the module is being loaded.
         resolve_imports:
             Whether to try and find all the named exports of this module.
         resolve_exports_depth:
             How deeply to search for those exports.
         unmount_before_update:
             Cause the component to be unmounted before each update. This option should
-            only be used if the imported package failes to re-render when props change.
+            only be used if the imported package fails to re-render when props change.
             Using this option has negative performance consequences since all DOM
             elements must be changed on each render. See :issue:`461` for more info.
     """
@@ -342,7 +342,7 @@ def export(
             will be returned. If a list is given, then a list of components will be
             returned.
         fallback:
-            What to temporarilly display while the module is being loaded.
+            What to temporarily display while the module is being loaded.
         allow_children:
             Whether or not these components can have children.
     """

--- a/src/py/reactpy/tests/conftest.py
+++ b/src/py/reactpy/tests/conftest.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--headed",
         dest="headed",
         action="store_true",
-        help="Open a browser window when runnging web-based tests",
+        help="Open a browser window when running web-based tests",
     )
 
 

--- a/src/py/reactpy/tests/test_backend/test_all.py
+++ b/src/py/reactpy/tests/test_backend/test_all.py
@@ -45,7 +45,7 @@ async def test_display_simple_hello_world(display: DisplayFixture):
 
     await display.page.wait_for_selector("#hello")
 
-    # test that we can reconnect succefully
+    # test that we can reconnect successfully
     await display.page.reload()
 
     await display.page.wait_for_selector("#hello")

--- a/src/py/reactpy/tests/test_client.py
+++ b/src/py/reactpy/tests/test_client.py
@@ -54,7 +54,7 @@ async def test_automatic_reconnect(browser: Browser):
             DisplayFixture(server, driver=page)
         )
 
-        # use mount instead of show to avoid a page refesh
+        # use mount instead of show to avoid a page refresh
         display.backend.mount(SomeComponent)
 
         async def get_count():

--- a/src/py/reactpy/tests/test_core/test_component.py
+++ b/src/py/reactpy/tests/test_core/test_component.py
@@ -60,7 +60,7 @@ async def test_pre_tags_are_rendered_correctly(display: DisplayFixture):
         return reactpy.html.pre(
             {"id": "pre-form-test"},
             reactpy.html.span("this", reactpy.html.span("is"), "some"),
-            "pre-Formatted",
+            "pre-formatted",
             " text",
         )
 

--- a/src/py/reactpy/tests/test_core/test_component.py
+++ b/src/py/reactpy/tests/test_core/test_component.py
@@ -56,18 +56,18 @@ async def test_display_simple_hello_world(display: DisplayFixture):
 
 async def test_pre_tags_are_rendered_correctly(display: DisplayFixture):
     @reactpy.component
-    def PreFormated():
+    def PreFormatted():
         return reactpy.html.pre(
             {"id": "pre-form-test"},
             reactpy.html.span("this", reactpy.html.span("is"), "some"),
-            "pre-formated",
+            "pre-Formatted",
             " text",
         )
 
-    await display.show(PreFormated)
+    await display.show(PreFormatted)
 
     pre = await display.page.wait_for_selector("#pre-form-test")
 
     assert (
         await pre.evaluate("node => node.innerHTML")
-    ) == "<span>this<span>is</span>some</span>pre-formated text"
+    ) == "<span>this<span>is</span>some</span>pre-Formatted text"

--- a/src/py/reactpy/tests/test_core/test_component.py
+++ b/src/py/reactpy/tests/test_core/test_component.py
@@ -70,4 +70,4 @@ async def test_pre_tags_are_rendered_correctly(display: DisplayFixture):
 
     assert (
         await pre.evaluate("node => node.innerHTML")
-    ) == "<span>this<span>is</span>some</span>pre-Formatted text"
+    ) == "<span>this<span>is</span>some</span>pre-formatted text"

--- a/src/py/reactpy/tests/test_core/test_events.py
+++ b/src/py/reactpy/tests/test_core/test_events.py
@@ -183,7 +183,7 @@ async def test_simple_click_event(display: DisplayFixture):
     await display.page.wait_for_selector("#complete")
 
 
-async def test_can_stop_event_Propagation(display: DisplayFixture):
+async def test_can_stop_event_propagation(display: DisplayFixture):
     clicked = reactpy.Ref(False)
 
     @reactpy.component

--- a/src/py/reactpy/tests/test_core/test_events.py
+++ b/src/py/reactpy/tests/test_core/test_events.py
@@ -183,7 +183,7 @@ async def test_simple_click_event(display: DisplayFixture):
     await display.page.wait_for_selector("#complete")
 
 
-async def test_can_stop_event_propogation(display: DisplayFixture):
+async def test_can_stop_event_Propagation(display: DisplayFixture):
     clicked = reactpy.Ref(False)
 
     @reactpy.component

--- a/src/py/reactpy/tests/test_core/test_hooks.py
+++ b/src/py/reactpy/tests/test_core/test_hooks.py
@@ -547,7 +547,7 @@ async def test_use_async_effect_cancel(caplog):
 
     # So I know we said the event never occurs but... to ensure the effect's future is
     # cancelled before the test is cleaned up we need to set the event. This is because
-    # the cancellation doesn't propogate before the test is resolved which causes
+    # the cancellation doesn't propagate before the test is resolved which causes
     # delayed log messages that impact other tests.
     event_that_never_occurs.set()
 

--- a/src/py/reactpy/tests/test_core/test_layout.py
+++ b/src/py/reactpy/tests/test_core/test_layout.py
@@ -414,7 +414,7 @@ async def test_life_cycle_hooks_are_garbage_collected():
 
     # For some reason, holding `set_inner_component` outside the render context causes
     # the associated hook to not be automatically garbage collected. After some
-    # imperical investigation, it seems that if we do not hold `set_inner_component` in
+    # empirical investigation, it seems that if we do not hold `set_inner_component` in
     # this way, the call to `gc.collect()` isn't required. This is demonstrated in
     # `test_root_component_life_cycle_hook_is_garbage_collected`
     gc.collect()
@@ -1173,8 +1173,8 @@ async def test_render_removed_context_consumer():
         await layout.render()
 
         # If the context provider does not render its children then internally tracked
-        # state for the removed child component might not be cleaned up propperly. This
-        # occured in the past when the context provider implemented a should_render()
+        # state for the removed child component might not be cleaned up properly. This
+        # occurred in the past when the context provider implemented a should_render()
         # method that returned False (and thus did not render its children) when the
         # context value did not change.
         toggle_remove_child()
@@ -1184,7 +1184,7 @@ async def test_render_removed_context_consumer():
         # correctly, scheduling a render for it might cause an error.
         schedule_removed_child_render()
 
-        # If things were cleaned up propperly, the above scheduled render should not
+        # If things were cleaned up properly, the above scheduled render should not
         # actually take place. Thus we expect the timeout to occur.
         render_task = asyncio.create_task(layout.render())
         done, pending = await asyncio.wait([render_task], timeout=0.1)

--- a/src/py/reactpy/tests/test_core/test_serve.py
+++ b/src/py/reactpy/tests/test_core/test_serve.py
@@ -18,7 +18,7 @@ STATIC_EVENT_HANDLER = StaticEventHandler()
 def make_send_recv_callbacks(events_to_inject):
     changes = []
 
-    # We need a semaphor here to simulate recieving an event after each update is sent.
+    # We need a semaphore here to simulate receiving an event after each update is sent.
     # The effect is that the send() and recv() callbacks trade off control. If we did
     # not do this, it would easy to determine when to halt because, while we might have
     # received all the events, they might not have been sent since the two callbacks are

--- a/src/py/reactpy/tests/test_core/test_vdom.py
+++ b/src/py/reactpy/tests/test_core/test_vdom.py
@@ -136,7 +136,7 @@ def test_make_vdom_constructor():
             "eventHandler": {
                 "target": "something",
                 "preventDefault": False,
-                "stopPropogation": True,
+                "stopPropagation": True,
             },
         },
         {
@@ -165,7 +165,7 @@ def test_make_vdom_constructor():
             "eventHandler": {
                 "target": "something",
                 "preventDefault": False,
-                "stopPropogation": True,
+                "stopPropagation": True,
             },
             "importSource": {
                 "source": "something",

--- a/src/py/reactpy/tests/test_testing.py
+++ b/src/py/reactpy/tests/test_testing.py
@@ -11,7 +11,7 @@ from reactpy.testing.backend import _hotswap
 from reactpy.testing.display import DisplayFixture
 
 
-def test_assert_reactpy_logged_does_not_supress_errors():
+def test_assert_reactpy_logged_does_not_suppress_errors():
     with pytest.raises(RuntimeError, match="expected error"):
         with testing.assert_reactpy_did_log():
             msg = "expected error"

--- a/src/py/reactpy/tests/tooling/common.py
+++ b/src/py/reactpy/tests/tooling/common.py
@@ -3,7 +3,7 @@ from typing import Any
 from reactpy.core.types import LayoutEventMessage, LayoutUpdateMessage
 
 # see: https://github.com/microsoft/playwright-python/issues/1614
-DEFAULT_TYPE_DELAY = 100  # miliseconds
+DEFAULT_TYPE_DELAY = 100  # milliseconds
 
 
 def event_message(target: str, *data: Any) -> LayoutEventMessage:

--- a/tasks.py
+++ b/tasks.py
@@ -315,7 +315,7 @@ def get_current_tags(context: Context) -> set[str]:
         context.run("git diff --cached --exit-code", hide=True)
         context.run("git diff --exit-code", hide=True)
     except Exception:
-        log.error("Cannot create a tag - there are uncommited changes")
+        log.error("Cannot create a tag - there are uncommitted changes")
         return set()
 
     tags_per_commit: dict[str, list[str]] = {}


### PR DESCRIPTION
## Issues

<!-- Link the issues this change resolves, or describe them -->

## Summary

Fix typos found via:
- `codespell -S package-lock.json -L inflight,ue,falsy`
- `typos --format brief`

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
