### PR TITLE
report better error for attrs that cannot be serialized

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app/
 
 # Install NodeJS
 # --------------
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -yq nodejs npm build-essential
+RUN apt-get install -y build-essential
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 RUN npm install -g npm@8.5.0
 
 # Install Poetry

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,9 +2,13 @@ FROM python:3.9
 
 WORKDIR /app/
 
+# Misc Dependencies
+# -----------------
+RUN apt-get update
+RUN apt-get install -y build-essential
+
 # Install NodeJS
 # --------------
-RUN apt-get install -y build-essential
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 RUN npm install -g npm@8.5.0
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,14 +2,10 @@ FROM python:3.9
 
 WORKDIR /app/
 
-# Misc Dependencies
-# -----------------
-RUN apt-get update
-RUN apt-get install -y build-essential
-
 # Install NodeJS
 # --------------
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y build-essential nodejs npm
 RUN npm install -g npm@8.5.0
 
 # Install Poetry

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/
 
 # Install NodeJS
 # --------------
-RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -yq nodejs build-essential
 RUN npm install -g npm@8.5.0
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app/
 # Install NodeJS
 # --------------
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -yq nodejs build-essential
+RUN apt-get install -yq nodejs npm build-essential
 RUN npm install -g npm@8.5.0
 
 # Install Poetry

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,10 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+**Fixed**
+
+- :issue:`930` - better traceback for JSON serialization errors (via :pull:`1008`)
+- :issue:`437` - explain that JS component attributes must be JSON (via :pull:`1008`)
 
 
 v1.0.0

--- a/src/py/reactpy/reactpy/_option.py
+++ b/src/py/reactpy/reactpy/_option.py
@@ -141,5 +141,14 @@ class DeprecatedOption(Option[_O]):
 
     @Option.current.getter  # type: ignore
     def current(self) -> _O:
-        warn(self._deprecation_message, DeprecationWarning)
+        try:
+            # we access the current value during init to debug log it
+            # no need to warn unless it's actually used. since this attr
+            # is only set after super().__init__ is called, we can check
+            # for it to determine if it's being accessed by a user.
+            msg = self._deprecation_message
+        except AttributeError:
+            pass
+        else:
+            warn(msg, DeprecationWarning)
         return super().current

--- a/src/py/reactpy/reactpy/_option.py
+++ b/src/py/reactpy/reactpy/_option.py
@@ -11,12 +11,6 @@ logger = getLogger(__name__)
 UNDEFINED = cast(Any, object())
 
 
-def deprecate(option: Option[_O], message: str) -> Option[_O]:
-    option.__class__ = _DeprecatedOption
-    option._deprecation_message = message
-    return option
-
-
 class Option(Generic[_O]):
     """An option that can be set using an environment variable of the same name"""
 
@@ -138,7 +132,13 @@ class Option(Generic[_O]):
         return f"Option({self._name}={self.current!r})"
 
 
-class _DeprecatedOption(Option[_O]):  # nocov
+class DeprecatedOption(Option[_O]):
+    """An option that will warn when it is accessed"""
+
+    def __init__(self, *args: Any, message: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._deprecation_message = message
+
     @Option.current.getter  # type: ignore
     def current(self) -> _O:
         warn(self._deprecation_message, DeprecationWarning)

--- a/src/py/reactpy/reactpy/backend/_common.py
+++ b/src/py/reactpy/reactpy/backend/_common.py
@@ -114,7 +114,7 @@ def vdom_head_elements_to_html(head: Sequence[VdomDict] | VdomDict | str) -> str
             head = cast(VdomDict, {**head, "tagName": ""})
         return vdom_to_html(head)
     else:
-        return vdom_to_html(html._(head))
+        return vdom_to_html(html._(*head))
 
 
 @dataclass

--- a/src/py/reactpy/reactpy/config.py
+++ b/src/py/reactpy/reactpy/config.py
@@ -3,6 +3,8 @@ ReactPy provides a series of configuration options that can be set using environ
 variables or, for those which allow it, a programmatic interface.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -12,9 +14,11 @@ TRUE_VALUES = {"true", "1"}
 FALSE_VALUES = {"false", "0"}
 
 
-def boolean(value: str | bool) -> bool:
+def boolean(value: str | bool | int) -> bool:
     if isinstance(value, bool):
         return value
+    elif isinstance(value, int):
+        return bool(value)
     elif not isinstance(value, str):
         raise TypeError(f"Expected str or bool, got {type(value).__name__}")
 

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -53,7 +53,7 @@ async def _single_outgoing_loop(
         update = await layout.render()
         try:
             await send(update)
-        except Exception:
+        except Exception:  # nocov
             if not REACTPY_DEBUG_MODE.current:
                 msg = (
                     "Failed to send update. More info may be available "

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -57,7 +57,7 @@ async def _single_outgoing_loop(
             if not REACTPY_DEBUG_MODE.current:
                 msg = (
                     "Failed to send update. More info may be available "
-                    "if you enabling debug mode by settings "
+                    "if you enabling debug mode by setting "
                     "`reactpy.config.REACTPY_DEBUG_MODE.current = True`."
                 )
                 logger.error(msg)

--- a/src/py/reactpy/reactpy/core/vdom.py
+++ b/src/py/reactpy/reactpy/core/vdom.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from collections.abc import Mapping, Sequence
 from functools import wraps
 from typing import Any, Protocol, cast, overload
@@ -25,9 +24,6 @@ from reactpy.core.types import (
     VdomDictConstructor,
     VdomJson,
 )
-
-logger = logging.getLogger()
-
 
 VDOM_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema",
@@ -328,18 +324,18 @@ def _is_single_child(value: Any) -> bool:
 
 def _validate_child_key_integrity(value: Any) -> None:
     if hasattr(value, "__iter__") and not hasattr(value, "__len__"):
-        logger.error(
+        warn(
             f"Did not verify key-path integrity of children in generator {value} "
             "- pass a sequence (i.e. list of finite length) in order to verify"
         )
     else:
         for child in value:
             if isinstance(child, ComponentType) and child.key is None:
-                logger.error(f"Key not specified for child in list {child}")
+                warn(f"Key not specified for child in list {child}")
             elif isinstance(child, Mapping) and "key" not in child:
                 # remove 'children' to reduce log spam
                 child_copy = {**child, "children": _EllipsisRepr()}
-                logger.error(f"Key not specified for child in list {child_copy}")
+                warn(f"Key not specified for child in list {child_copy}")
 
 
 class _CustomVdomDictConstructor(Protocol):

--- a/src/py/reactpy/reactpy/core/vdom.py
+++ b/src/py/reactpy/reactpy/core/vdom.py
@@ -331,11 +331,11 @@ def _validate_child_key_integrity(value: Any) -> None:
     else:
         for child in value:
             if isinstance(child, ComponentType) and child.key is None:
-                warn(f"Key not specified for child in list {child}")
+                warn(f"Key not specified for child in list {child}", UserWarning)
             elif isinstance(child, Mapping) and "key" not in child:
                 # remove 'children' to reduce log spam
                 child_copy = {**child, "children": _EllipsisRepr()}
-                warn(f"Key not specified for child in list {child_copy}")
+                warn(f"Key not specified for child in list {child_copy}", UserWarning)
 
 
 class _CustomVdomDictConstructor(Protocol):

--- a/src/py/reactpy/reactpy/core/vdom.py
+++ b/src/py/reactpy/reactpy/core/vdom.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Mapping, Sequence
 from functools import wraps
@@ -8,7 +9,7 @@ from typing import Any, Protocol, cast, overload
 from fastjsonschema import compile as compile_json_schema
 
 from reactpy._warnings import warn
-from reactpy.config import REACTPY_DEBUG_MODE
+from reactpy.config import REACTPY_CHECK_JSON_ATTRS, REACTPY_DEBUG_MODE
 from reactpy.core._f_back import f_module_name
 from reactpy.core.events import EventHandler, to_event_handler_function
 from reactpy.core.types import (
@@ -199,6 +200,8 @@ def vdom(
     attributes, event_handlers = separate_attributes_and_event_handlers(attributes)
 
     if attributes:
+        if REACTPY_CHECK_JSON_ATTRS.current:
+            json.dumps(attributes)
         model["attributes"] = attributes
 
     if children:

--- a/src/py/reactpy/tests/test__option.py
+++ b/src/py/reactpy/tests/test__option.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from reactpy._option import DeprecatedOption, Option
+from reactpy._option import Option, deprecate
 
 
 def test_option_repr():
@@ -33,7 +33,7 @@ def test_option_validator():
     opt.current = "0"
     assert opt.current is False
 
-    with pytest.raises(ValueError, match="invalid literal for int"):
+    with pytest.raises(ValueError, match="Invalid value"):
         opt.current = "not-an-int"
 
 
@@ -102,10 +102,29 @@ def test_option_subscribe():
 
 
 def test_deprecated_option():
-    opt = DeprecatedOption("is deprecated!", "A_FAKE_OPTION", None)
+    opt = deprecate(Option("A_FAKE_OPTION", None), "is deprecated!")
 
     with pytest.warns(DeprecationWarning, match="is deprecated!"):
         assert opt.current is None
 
     with pytest.warns(DeprecationWarning, match="is deprecated!"):
         opt.current = "something"
+
+
+def test_option_parent():
+    parent_opt = Option("A_FAKE_OPTION", "default-value", mutable=True)
+    child_opt = Option("A_FAKE_OPTION", parent=parent_opt)
+    assert child_opt.mutable
+    assert child_opt.current == "default-value"
+
+    parent_opt.current = "new-value"
+    assert child_opt.current == "new-value"
+
+
+def test_option_parent_child_must_be_mutable():
+    mut_parent_opt = Option("A_FAKE_OPTION", "default-value", mutable=True)
+    immu_parent_opt = Option("A_FAKE_OPTION", "default-value", mutable=False)
+    with pytest.raises(TypeError, match="must be mutable"):
+        Option("A_FAKE_OPTION", parent=mut_parent_opt, mutable=False)
+    with pytest.raises(TypeError, match="must be mutable"):
+        Option("A_FAKE_OPTION", parent=immu_parent_opt, mutable=None)

--- a/src/py/reactpy/tests/test__option.py
+++ b/src/py/reactpy/tests/test__option.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from reactpy._option import Option, deprecate
+from reactpy._option import DeprecatedOption, Option
 
 
 def test_option_repr():
@@ -102,7 +102,7 @@ def test_option_subscribe():
 
 
 def test_deprecated_option():
-    opt = deprecate(Option("A_FAKE_OPTION", None), "is deprecated!")
+    opt = DeprecatedOption("A_FAKE_OPTION", None, message="is deprecated!")
 
     with pytest.warns(DeprecationWarning, match="is deprecated!"):
         assert opt.current is None

--- a/src/py/reactpy/tests/test__option.py
+++ b/src/py/reactpy/tests/test__option.py
@@ -132,6 +132,6 @@ def test_option_parent_child_must_be_mutable():
 
 def test_no_default_or_parent():
     with pytest.raises(
-        TypeError, match="must specify either a default value or a parent"
+        TypeError, match="Must specify either a default or a parent option"
     ):
         Option("A_FAKE_OPTION")

--- a/src/py/reactpy/tests/test__option.py
+++ b/src/py/reactpy/tests/test__option.py
@@ -128,3 +128,10 @@ def test_option_parent_child_must_be_mutable():
         Option("A_FAKE_OPTION", parent=mut_parent_opt, mutable=False)
     with pytest.raises(TypeError, match="must be mutable"):
         Option("A_FAKE_OPTION", parent=immu_parent_opt, mutable=None)
+
+
+def test_no_default_or_parent():
+    with pytest.raises(
+        TypeError, match="must specify either a default value or a parent"
+    ):
+        Option("A_FAKE_OPTION")

--- a/src/py/reactpy/tests/test_config.py
+++ b/src/py/reactpy/tests/test_config.py
@@ -27,3 +27,27 @@ def test_reactpy_debug_mode_toggle():
     # just check that nothing breaks
     config.REACTPY_DEBUG_MODE.current = True
     config.REACTPY_DEBUG_MODE.current = False
+
+
+def test_boolean():
+    assert config.boolean(True) is True
+    assert config.boolean(False) is False
+    assert config.boolean(1) is True
+    assert config.boolean(0) is False
+    assert config.boolean("true") is True
+    assert config.boolean("false") is False
+    assert config.boolean("True") is True
+    assert config.boolean("False") is False
+    assert config.boolean("TRUE") is True
+    assert config.boolean("FALSE") is False
+    assert config.boolean("1") is True
+    assert config.boolean("0") is False
+
+    with pytest.raises(ValueError):
+        config.boolean("2")
+
+    with pytest.raises(ValueError):
+        config.boolean("")
+
+    with pytest.raises(TypeError):
+        config.boolean(None)

--- a/src/py/reactpy/tests/test_core/test_hooks.py
+++ b/src/py/reactpy/tests/test_core/test_hooks.py
@@ -1257,12 +1257,3 @@ async def test_error_in_component_effect_cleanup_is_gracefully_handled():
             await layout.render()
             component_hook.latest.schedule_render()
             await layout.render()  # no error
-
-
-@pytest.mark.skipif(
-    not REACTPY_DEBUG_MODE.current,
-    reason="only check json serialization in debug mode",
-)
-def test_raise_for_non_json_attrs():
-    with pytest.raises(TypeError, match="JSON serializable"):
-        reactpy.html.div({"non_json_serializable_object": object()})

--- a/src/py/reactpy/tests/test_core/test_hooks.py
+++ b/src/py/reactpy/tests/test_core/test_hooks.py
@@ -1257,3 +1257,12 @@ async def test_error_in_component_effect_cleanup_is_gracefully_handled():
             await layout.render()
             component_hook.latest.schedule_render()
             await layout.render()  # no error
+
+
+@pytest.mark.skipif(
+    not REACTPY_DEBUG_MODE.current,
+    reason="only check json serialization in debug mode",
+)
+def test_raise_for_non_json_attrs():
+    with pytest.raises(TypeError, match="JSON serializable"):
+        reactpy.html.div({"non_json_serializable_object": object()})

--- a/src/py/reactpy/tests/test_utils.py
+++ b/src/py/reactpy/tests/test_utils.py
@@ -205,10 +205,6 @@ SOME_OBJECT = object()
             f"<div>{html_escape(str(SOME_OBJECT))}</div>",
         ),
         (
-            html.div({"someAttribute": SOME_OBJECT}),
-            f'<div someattribute="{html_escape(str(SOME_OBJECT))}"></div>',
-        ),
-        (
             html.div(
                 "hello", html.a({"href": "https://example.com"}, "example"), "world"
             ),


### PR DESCRIPTION
## Issues

closes: #930
closes: #437

## Summary

In `reactpy.core.vdom.vdom` check if attributes are JSON serializable when in debug mode.

Also misc changes to config options to make this easier in particular ability to specify options as parents.

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
