### PR TITLE
Fix the Django project URL

### DIFF
--- a/docs/source/guides/getting-started/installing-reactpy.rst
+++ b/docs/source/guides/getting-started/installing-reactpy.rst
@@ -75,7 +75,7 @@ run ReactPy in these supported frameworks, follow the links below:
 .. grid:: 3
 
     .. grid-item-card::
-        :link: https://github.com/reactive-python/django-reactpy
+        :link: https://github.com/reactive-python/reactpy-django
         :img-background: _static/logo-django.svg
         :class-card: card-logo-image
 


### PR DESCRIPTION
There must have been a rename of the repo - this is the correct on.

## Issues

<!-- Link the issues this change resolves, or describe them -->

## Summary

<!-- Describe how these changes resolve the aforementioned issues -->

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
