### PR TITLE
Fixed FileNotFound error while running hatch run lint-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,8 @@ ignore = [
   "S105", "S106", "S107",
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  # Ignore escape sequence: `\ `
+  "W605",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ ignore = [
   "S105", "S106", "S107",
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
-  # Ignore escape sequence: `\ `
-  "W605",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/tasks.py
+++ b/tasks.py
@@ -106,9 +106,10 @@ def lint_py(context: Context, fix: bool = False):
     else:
         context.run("ruff .")
         context.run("black --check --diff .")
+        path = str(ROOT).replace(" ", "\ ") + "/pyproject.toml"
         in_py(
             context,
-            f"flake8 --toml-config {ROOT / 'pyproject.toml'} .",
+            f"flake8 --toml-config {path} .",
             "hatch run lint:all",
         )
 

--- a/tasks.py
+++ b/tasks.py
@@ -106,10 +106,9 @@ def lint_py(context: Context, fix: bool = False):
     else:
         context.run("ruff .")
         context.run("black --check --diff .")
-        path = str(ROOT).replace(" ", "\ ") + "/pyproject.toml"
         in_py(
             context,
-            f"flake8 --toml-config {path} .",
+            f"flake8 --toml-config '{ROOT / 'pyproject.toml'}' .",
             "hatch run lint:all",
         )
 


### PR DESCRIPTION
## Issues

Resolve #1022 

## Summary

Replace white space inside the path with `\ ` so that os can detect the file

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
