### PR TITLE
Unpin reactpy client version

### DIFF
--- a/docs/source/guides/getting-started/_static/embed-doc-ex.html
+++ b/docs/source/guides/getting-started/_static/embed-doc-ex.html
@@ -1,6 +1,6 @@
 <div id="reactpy-app" />
 <script type="module">
-  import { mountLayoutWithWebSocket } from "https://esm.sh/@reactpy/client@0.33.3";
+  import { mountLayoutWithWebSocket } from "https://esm.sh/@reactpy/client";
   mountLayoutWithWebSocket(
     document.getElementById("reactpy-app"),
     "wss://reactpy.dev/_reactpy/stream?view_id=todo"


### PR DESCRIPTION
Until we have a template tag, we're better off completely unpinning the reactpy client version.