### PR TITLE
docs:fixed two typos inside Dangers of mutability

### DIFF
--- a/docs/source/guides/adding-interactivity/dangers-of-mutability/index.rst
+++ b/docs/source/guides/adding-interactivity/dangers-of-mutability/index.rst
@@ -42,8 +42,8 @@ facilitate change:
     values are equivalent with the ``==`` or ``!=`` operators.
 
 Thus far, all the values we've been working with have been immutable. These include
-:class:`int`, :class:`float`, :class:`str`, and :class:`bool` values. As a result, we've
-have not had to consider the consiquences of mutations.
+:class:`int`, :class:`float`, :class:`str`, and :class:`bool` values. As a result, we
+have not had to consider the consequences of mutations.
 
 
 .. _Why Avoid Mutation:


### PR DESCRIPTION
## Summary

- fixed two typos in "Dangers of mutability"
- "we've have" -> "we have"
- "consiquences" -> "consequences"