### PR TITLE
Better Error message if no backend installed #1042

### DIFF
--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -63,7 +63,7 @@ def _default_implementation() -> BackendImplementation[Any]:
         msg = (
             "It seems you haven't installed a backend. To resolve this issue, "
             "you can install a backend by running:\n\n"
-            'pip install "reactpy[starlette]"\n\n'
+            '\033[1mpip install "reactpy[starlette]"\033[0m\n\n'
             f"Other supported backends include: {supported_backends}."
         )
         raise RuntimeError(msg) from None

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -62,8 +62,11 @@ def _default_implementation() -> BackendImplementation[Any]:
         supported_backends = ", ".join(SUPPORTED_PACKAGES)
         msg = (
             "It seems you haven't installed a backend. To resolve this issue, "
+
             "you can install a backend by running:\n\n"
+
             'pip install "reactpy[starlette]"\n\n'
+            
             f"Other supported backends include: {supported_backends}."
         )
 

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -60,10 +60,12 @@ def _default_implementation() -> BackendImplementation[Any]:
     except StopIteration:  # nocov
         logger.debug("Backend implementation import failed", exc_info=exc_info())
         supported_backends = ", ".join(SUPPORTED_PACKAGES)
-        msg = ("It seems you haven't installed a backend. To resolve this issue, "
-       "you can install a backend by running:\n\n"
-       'pip install "reactpy[starlette]"\n\n'
-       f"Other supported backends include: {supported_backends}.")
+        msg = (
+            "It seems you haven't installed a backend. To resolve this issue, "
+            "you can install a backend by running:\n\n"
+            'pip install "reactpy[starlette]"\n\n'
+            f"Other supported backends include: {supported_backends}."
+        )
 
         raise RuntimeError(msg) from None
     else:

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -62,14 +62,10 @@ def _default_implementation() -> BackendImplementation[Any]:
         supported_backends = ", ".join(SUPPORTED_PACKAGES)
         msg = (
             "It seems you haven't installed a backend. To resolve this issue, "
-
             "you can install a backend by running:\n\n"
-
             'pip install "reactpy[starlette]"\n\n'
-            
             f"Other supported backends include: {supported_backends}."
         )
-
         raise RuntimeError(msg) from None
     else:
         _DEFAULT_IMPLEMENTATION = implementation

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -6,6 +6,7 @@ from sys import exc_info
 from typing import Any, NoReturn
 
 from reactpy.backend.types import BackendImplementation
+from reactpy.backend.utils import SUPPORTED_PACKAGES
 from reactpy.backend.utils import all_implementations
 from reactpy.types import RootComponentConstructor
 
@@ -59,7 +60,10 @@ def _default_implementation() -> BackendImplementation[Any]:
         implementation = next(all_implementations())
     except StopIteration:  # nocov
         logger.debug("Backend implementation import failed", exc_info=exc_info())
-        msg = "No built-in server implementation installed."
+        supported_backends = ', '.join(SUPPORTED_PACKAGES)
+        msg = "It seems you haven't installed any built-in backends. \n" \
+            "To resolve this issue, you can install a backend like 'reactpy[starlette]' or any other supported backend.\n" \
+            f"The list of supported backends is: {supported_backends}."     
         raise RuntimeError(msg) from None
     else:
         _DEFAULT_IMPLEMENTATION = implementation

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -63,7 +63,7 @@ def _default_implementation() -> BackendImplementation[Any]:
         supported_backends = ', '.join(SUPPORTED_PACKAGES)
         msg = "It seems you haven't installed an backend. To resolve this issue, you can install a backend by running \n"\
             "\n" \
-           'pip install "reactpy[starlette]"\n'\
+           'pip install "reactpy[starlette]"\n\n'\
             f"Other supported backends include: {supported_backends}."     
         raise RuntimeError(msg) from None
     else:

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -6,8 +6,7 @@ from sys import exc_info
 from typing import Any, NoReturn
 
 from reactpy.backend.types import BackendImplementation
-from reactpy.backend.utils import SUPPORTED_PACKAGES
-from reactpy.backend.utils import all_implementations
+from reactpy.backend.utils import SUPPORTED_PACKAGES, all_implementations
 from reactpy.types import RootComponentConstructor
 
 logger = getLogger(__name__)
@@ -60,11 +59,12 @@ def _default_implementation() -> BackendImplementation[Any]:
         implementation = next(all_implementations())
     except StopIteration:  # nocov
         logger.debug("Backend implementation import failed", exc_info=exc_info())
-        supported_backends = ', '.join(SUPPORTED_PACKAGES)
-        msg = "It seems you haven't installed an backend. To resolve this issue, you can install a backend by running \n"\
-            "\n" \
-           'pip install "reactpy[starlette]"\n\n'\
-            f"Other supported backends include: {supported_backends}."     
+        supported_backends = ", ".join(SUPPORTED_PACKAGES)
+        msg = ("It seems you haven't installed a backend. To resolve this issue, "
+       "you can install a backend by running:\n\n"
+       'pip install "reactpy[starlette]"\n\n'
+       f"Other supported backends include: {supported_backends}.")
+
         raise RuntimeError(msg) from None
     else:
         _DEFAULT_IMPLEMENTATION = implementation

--- a/src/py/reactpy/reactpy/backend/default.py
+++ b/src/py/reactpy/reactpy/backend/default.py
@@ -61,9 +61,10 @@ def _default_implementation() -> BackendImplementation[Any]:
     except StopIteration:  # nocov
         logger.debug("Backend implementation import failed", exc_info=exc_info())
         supported_backends = ', '.join(SUPPORTED_PACKAGES)
-        msg = "It seems you haven't installed any built-in backends. \n" \
-            "To resolve this issue, you can install a backend like 'reactpy[starlette]' or any other supported backend.\n" \
-            f"The list of supported backends is: {supported_backends}."     
+        msg = "It seems you haven't installed an backend. To resolve this issue, you can install a backend by running \n"\
+            "\n" \
+           'pip install "reactpy[starlette]"\n'\
+            f"Other supported backends include: {supported_backends}."     
         raise RuntimeError(msg) from None
     else:
         _DEFAULT_IMPLEMENTATION = implementation


### PR DESCRIPTION
## Issues

closes: #1042 

## Summary

- Added a better error message stating that no backend is installed 
- Suggested list of supported backends (imported from reactpy.backend.utils) 
