### PR TITLE
Warn and fix missing mime types

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,9 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+**Fixed**
+
+- :pull:`1050` - Fix issue where JavaScript files can be detected as mime-type ``text/plain`` due to a corrupt Windows registry
 
 
 v1.0.0

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,9 +23,9 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-**Fixed**
+**Changed**
 
-- :pull:`1050` - Fix issue where JavaScript files can be detected as mime-type ``text/plain`` due to a corrupt Windows registry
+- :pull:`1050` - Warn when operating system has missing mime types, which can result in ``reactpy.run`` not working as expected.
 
 
 v1.0.0

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -25,7 +25,7 @@ Unreleased
 
 **Changed**
 
-- :pull:`1050` - Warn when operating system has missing mime types, which can result in ``reactpy.run`` not working as expected.
+- :pull:`1050` - Warn and attempt to fix missing mime types, which can result in ``reactpy.run`` not working as expected.
 
 **Fixed**
 

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -7,12 +7,11 @@ _logger = getLogger(__name__)
 # Example: https://github.com/encode/starlette/issues/829
 if not mimetypes.inited:
     mimetypes.init()
-MIME_TYPES = {
+for extension, mime_type in {
     ".js": "application/javascript",
     ".css": "text/css",
     ".json": "application/json",
-}
-for extension, mime_type in MIME_TYPES.items():
+}.items():
     if not mimetypes.types_map.get(extension):  # pragma: no cover
         _logger.warning(
             "Mime type '%s = %s' is missing. Please research how to "

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -1,4 +1,7 @@
 import mimetypes
+from logging import getLogger
+
+_logger = getLogger(__name__)
 
 # Fix for issue where Windows registry gets corrupt and mime types go missing
 if not mimetypes.inited:
@@ -10,4 +13,8 @@ MIME_TYPES = {
 }
 for extension, mime_type in MIME_TYPES.items():
     if not mimetypes.types_map.get(extension):  # pragma: no cover
+        _logger.warning(
+            f"Mime type '{mime_type}:{extension}' is missing."
+            " Please determine how to fix missing mime types on your OS."
+        )
         mimetypes.add_type(mime_type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -14,7 +14,9 @@ MIME_TYPES = {
 for extension, mime_type in MIME_TYPES.items():
     if not mimetypes.types_map.get(extension):  # pragma: no cover
         _logger.warning(
-            f"Mime type '{mime_type}:{extension}' is missing."
-            " Please determine how to fix missing mime types on your OS."
+            "Mime type '%s = %s' is missing. Please research how to "
+            "fix missing mime types on your operating system.",
+            extension,
+            mime_type,
         )
         mimetypes.add_type(mime_type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -5,11 +5,6 @@ mimetypes.init()
 MIME_TYPES = {
     ".js": "application/javascript",
     ".css": "text/css",
-    ".ico": "image/x-icon",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".svg": "image/svg+xml",
     ".json": "application/json",
 }
 for extension, mime_type in MIME_TYPES.items():

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -1,12 +1,13 @@
 import mimetypes
 
 # Fix for issue where Windows registry gets corrupt and mime types go missing
-mimetypes.init()
+if not mimetypes.inited: # pragma: no cover
+    mimetypes.init()
 MIME_TYPES = {
     ".js": "application/javascript",
     ".css": "text/css",
     ".json": "application/json",
 }
 for extension, mime_type in MIME_TYPES.items():
-    if not mimetypes.types_map.get(extension):
+    if not mimetypes.types_map.get(extension): # pragma: no cover
         mimetypes.add_type(mime_type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 _logger = getLogger(__name__)
 
-# Fix for missing mime types due to corrupt Windows registry
+# Fix for missing mime types due to OS corruption/misconfiguration
 if not mimetypes.inited:
     mimetypes.init()
 MIME_TYPES = {

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -1,7 +1,7 @@
 import mimetypes
 
 # Fix for issue where Windows registry gets corrupt and mime types go missing
-if not mimetypes.inited:  # pragma: no cover
+if not mimetypes.inited:
     mimetypes.init()
 MIME_TYPES = {
     ".js": "application/javascript",

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -4,6 +4,7 @@ from logging import getLogger
 _logger = getLogger(__name__)
 
 # Fix for missing mime types due to OS corruption/misconfiguration
+# Example: https://github.com/encode/starlette/issues/829
 if not mimetypes.inited:
     mimetypes.init()
 MIME_TYPES = {

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -1,0 +1,7 @@
+import mimetypes
+
+# Fix for issue where Windows registry gets corrupt and mime types go missing
+mimetypes.init()
+for extension, type in mimetypes.common_types.items():
+    if not mimetypes.types_map.get(extension):
+        mimetypes.add_type(type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -1,7 +1,7 @@
 import mimetypes
 
 # Fix for issue where Windows registry gets corrupt and mime types go missing
-if not mimetypes.inited: # pragma: no cover
+if not mimetypes.inited:  # pragma: no cover
     mimetypes.init()
 MIME_TYPES = {
     ".js": "application/javascript",
@@ -9,5 +9,5 @@ MIME_TYPES = {
     ".json": "application/json",
 }
 for extension, mime_type in MIME_TYPES.items():
-    if not mimetypes.types_map.get(extension): # pragma: no cover
+    if not mimetypes.types_map.get(extension):  # pragma: no cover
         mimetypes.add_type(mime_type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -2,6 +2,16 @@ import mimetypes
 
 # Fix for issue where Windows registry gets corrupt and mime types go missing
 mimetypes.init()
-for extension, mime_type in mimetypes.common_types.items():
+MIME_TYPES = {
+    ".js": "application/javascript",
+    ".css": "text/css",
+    ".ico": "image/x-icon",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".svg": "image/svg+xml",
+    ".json": "application/json",
+}
+for extension, mime_type in MIME_TYPES.items():
     if not mimetypes.types_map.get(extension):
         mimetypes.add_type(mime_type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -2,6 +2,6 @@ import mimetypes
 
 # Fix for issue where Windows registry gets corrupt and mime types go missing
 mimetypes.init()
-for extension, type in mimetypes.common_types.items():
+for extension, mime_type in mimetypes.common_types.items():
     if not mimetypes.types_map.get(extension):
-        mimetypes.add_type(type, extension)
+        mimetypes.add_type(mime_type, extension)

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 _logger = getLogger(__name__)
 
-# Fix for missing mime types due to corrupt Windows registry 
+# Fix for missing mime types due to corrupt Windows registry
 if not mimetypes.inited:
     mimetypes.init()
 MIME_TYPES = {

--- a/src/py/reactpy/reactpy/backend/__init__.py
+++ b/src/py/reactpy/reactpy/backend/__init__.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 _logger = getLogger(__name__)
 
-# Fix for issue where Windows registry gets corrupt and mime types go missing
+# Fix for missing mime types due to corrupt Windows registry 
 if not mimetypes.inited:
     mimetypes.init()
 MIME_TYPES = {


### PR DESCRIPTION
## Issues

N/A

## Summary

Windows registry can [sometimes go corrupt](https://github.com/encode/starlette/issues/829) causing missing mime types. This results in our backends assuming all file types are `text/plain`. Ultimately, this causes us to fail to serve our ReactPy client `index.js`.

This PR aims to only resolve a minimal set of file extensions (only the ones we potentially use within ReactPy core). I considered using a more comprehensive `mime_types` list from [this repo](https://github.com/micnic/mime.json), but it seems a bit overkill for us right now. We may want to use it if we need to serve a variety of static files. 

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
