### PR TITLE
Better Async Effects

### DIFF
--- a/.github/workflows/.hatch-run.yml
+++ b/.github/workflows/.hatch-run.yml
@@ -16,7 +16,7 @@ on:
       python-version-array:
         required: false
         type: string
-        default: '["3.x"]'
+        default: '["3.11"]'
       node-registry-url:
         required: false
         type: string

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -28,6 +28,14 @@ Unreleased
 - :pull:`1118` - `module_from_template` is broken with a recent release of `requests`
 - :pull:`1131` - `module_from_template` did not work when using Flask backend
 
+**Added**
+
+- :pull:`1093` - Better async effects (see :ref:`Async Effects`)
+- :pull:`1093` - Support concurrent renders - multiple components are now able to render
+  simultaneously. This is a significant change to the underlying rendering logic and
+  should be considered experimental. You can enable this feature by setting
+  ``REACTPY_FEATURE_CONCURRENT_RENDER=1`` when running ReactPy.
+
 
 v1.0.2
 ------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -322,6 +322,7 @@ intersphinx_mapping = {
     "sanic": ("https://sanic.readthedocs.io/en/latest/", None),
     "tornado": ("https://www.tornadoweb.org/en/stable/", None),
     "flask": ("https://flask.palletsprojects.com/en/1.1.x/", None),
+    "anyio": ("https://anyio.readthedocs.io/en/stable", None),
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,9 @@ ignore = [
   "PLR0915",
 ]
 unfixable = [
-  # Don't touch unused imports
+  # Don't touch unused imports or unused variables
   "F401",
+  "F841",
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
   "semver >=2, <3",
   "twine",
   "pre-commit",
+  # required by some packages during install
+  "setuptools",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/src/py/reactpy/pyproject.toml
+++ b/src/py/reactpy/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
   "colorlog >=6",
   "asgiref >=3",
   "lxml >=4",
+  # required by some packages during install
+  "setuptools",
 ]
 [project.optional-dependencies]
 all = ["reactpy[starlette,sanic,fastapi,flask,tornado,testing]"]
@@ -92,8 +94,8 @@ dependencies = [
   "jsonpointer",
 ]
 [tool.hatch.envs.default.scripts]
-test = "playwright install && pytest {args:tests}"
-test-cov = "playwright install && coverage run -m pytest {args:tests}"
+test = "playwright install chromium && pytest {args:tests}"
+test-cov = "playwright install chromium && coverage run -m pytest {args:tests}"
 cov-report = [
   # "- coverage combine",
   "coverage report",

--- a/src/py/reactpy/reactpy/backend/hooks.py
+++ b/src/py/reactpy/reactpy/backend/hooks.py
@@ -4,7 +4,8 @@ from collections.abc import MutableMapping
 from typing import Any
 
 from reactpy.backend.types import Connection, Location
-from reactpy.core.hooks import Context, create_context, use_context
+from reactpy.core.hooks import create_context, use_context
+from reactpy.core.types import Context
 
 # backend implementations should establish this context at the root of an app
 ConnectionContext: Context[Connection[Any] | None] = create_context(None)

--- a/src/py/reactpy/reactpy/config.py
+++ b/src/py/reactpy/reactpy/config.py
@@ -88,3 +88,11 @@ REACTPY_EFFECT_DEFAULT_STOP_TIMEOUT = Option(
     validator=float,
 )
 """The default amount of time to wait for an effect to complete"""
+
+REACTPY_CONCURRENT_RENDERING = Option(
+    "REACTPY_CONCURRENT_RENDERING",
+    default=False,
+    mutable=True,
+    validator=boolean,
+)
+"""Whether to render components concurrently. This is currently an experimental feature."""

--- a/src/py/reactpy/reactpy/config.py
+++ b/src/py/reactpy/reactpy/config.py
@@ -80,3 +80,11 @@ REACTPY_TESTING_DEFAULT_TIMEOUT = Option(
     validator=float,
 )
 """A default timeout for testing utilities in ReactPy"""
+
+REACTPY_EFFECT_DEFAULT_STOP_TIMEOUT = Option(
+    "REACTPY_EFFECT_DEFAULT_STOP_TIMEOUT",
+    30.0,
+    mutable=False,
+    validator=float,
+)
+"""The default amount of time to wait for an effect to complete"""

--- a/src/py/reactpy/reactpy/core/_life_cycle_hook.py
+++ b/src/py/reactpy/reactpy/core/_life_cycle_hook.py
@@ -41,12 +41,8 @@ class LifeCycleHook:
 
         .. testcode::
 
-            from reactpy.core.hooks import (
-                current_hook,
-                LifeCycleHook,
-                COMPONENT_DID_RENDER_EFFECT,
-            )
-
+            from reactpy.core._life_cycle_hooks import LifeCycleHook
+            from reactpy.core.hooks import current_hook, COMPONENT_DID_RENDER_EFFECT
 
             # this function will come from a layout implementation
             schedule_render = lambda: ...

--- a/src/py/reactpy/reactpy/core/_life_cycle_hook.py
+++ b/src/py/reactpy/reactpy/core/_life_cycle_hook.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, Protocol, TypeVar
+from weakref import WeakSet
+
+from typing_extensions import TypeAlias
+
+from reactpy.core._thread_local import ThreadLocal
+from reactpy.core.types import ComponentType, Key, VdomDict
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+
+def current_hook() -> LifeCycleHook:
+    """Get the current :class:`LifeCycleHook`"""
+    hook_stack = _hook_stack.get()
+    if not hook_stack:
+        msg = "No life cycle hook is active. Are you rendering in a layout?"
+        raise RuntimeError(msg)
+    return hook_stack[-1]
+
+
+_hook_stack: ThreadLocal[list[LifeCycleHook]] = ThreadLocal(list)
+
+
+class Context(Protocol[T]):
+    """Returns a :class:`ContextProvider` component"""
+
+    def __call__(
+        self,
+        *children: Any,
+        value: T = ...,
+        key: Key | None = ...,
+    ) -> ContextProvider[T]:
+        ...
+
+
+class ContextProvider(Generic[T]):
+    def __init__(
+        self,
+        *children: Any,
+        value: T,
+        key: Key | None,
+        type: Context[T],
+    ) -> None:
+        self.children = children
+        self.key = key
+        self.type = type
+        self._value = value
+
+    def render(self) -> VdomDict:
+        current_hook().set_context_provider(self)
+        return {"tagName": "", "children": self.children}
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.type})"
+
+
+@dataclass(frozen=True)
+class EffectInfo:
+    task: asyncio.Task[None]
+    stop: asyncio.Event
+
+
+class LifeCycleHook:
+    """Defines the life cycle of a layout component.
+
+    Components can request access to their own life cycle events and state through hooks
+    while :class:`~reactpy.core.proto.LayoutType` objects drive drive the life cycle
+    forward by triggering events and rendering view changes.
+
+    Example:
+
+        If removed from the complexities of a layout, a very simplified full life cycle
+        for a single component with no child components would look a bit like this:
+
+        .. testcode::
+
+            from reactpy.core.hooks import (
+                current_hook,
+                LifeCycleHook,
+                COMPONENT_DID_RENDER_EFFECT,
+            )
+
+
+            # this function will come from a layout implementation
+            schedule_render = lambda: ...
+
+            # --- start life cycle ---
+
+            hook = LifeCycleHook(schedule_render)
+
+            # --- start render cycle ---
+
+            component = ...
+            await hook.affect_component_will_render(component)
+            try:
+                # render the component
+                ...
+
+                # the component may access the current hook
+                assert current_hook() is hook
+
+                # and save state or add effects
+                current_hook().use_state(lambda: ...)
+                current_hook().add_effect(COMPONENT_DID_RENDER_EFFECT, lambda: ...)
+            finally:
+                await hook.affect_component_did_render()
+
+            # This should only be called after the full set of changes associated with a
+            # given render have been completed.
+            await hook.affect_layout_did_render()
+
+            # Typically an event occurs and a new render is scheduled, thus beginning
+            # the render cycle anew.
+            hook.schedule_render()
+
+
+            # --- end render cycle ---
+
+            hook.affect_component_will_unmount()
+            del hook
+
+            # --- end render cycle ---
+    """
+
+    __slots__ = (
+        "__weakref__",
+        "_context_providers",
+        "_current_state_index",
+        "_effect_funcs",
+        "_effect_infos",
+        "_is_rendering",
+        "_rendered_atleast_once",
+        "_schedule_render_callback",
+        "_schedule_render_later",
+        "_state",
+        "component",
+    )
+
+    component: ComponentType
+
+    def __init__(
+        self,
+        schedule_render: Callable[[], None],
+    ) -> None:
+        self._context_providers: dict[Context[Any], ContextProvider[Any]] = {}
+        self._schedule_render_callback = schedule_render
+        self._schedule_render_later = False
+        self._is_rendering = False
+        self._rendered_atleast_once = False
+        self._current_state_index = 0
+        self._state: tuple[Any, ...] = ()
+        self._effect_funcs: list[_EffectStarter] = []
+        self._effect_infos: WeakSet[EffectInfo] = WeakSet()
+
+    def schedule_render(self) -> None:
+        if self._is_rendering:
+            self._schedule_render_later = True
+        else:
+            self._schedule_render()
+
+    def use_state(self, function: Callable[[], T]) -> T:
+        if not self._rendered_atleast_once:
+            # since we're not initialized yet we're just appending state
+            result = function()
+            self._state += (result,)
+        else:
+            # once finalized we iterate over each succesively used piece of state
+            result = self._state[self._current_state_index]
+        self._current_state_index += 1
+        return result
+
+    def add_effect(self, start_effect: _EffectStarter) -> None:
+        """Trigger a function on the occurrence of the given effect type"""
+        self._effect_funcs.append(start_effect)
+
+    def set_context_provider(self, provider: ContextProvider[Any]) -> None:
+        self._context_providers[provider.type] = provider
+
+    def get_context_provider(self, context: Context[T]) -> ContextProvider[T] | None:
+        return self._context_providers.get(context)
+
+    async def affect_component_will_render(self, component: ComponentType) -> None:
+        """The component is about to render"""
+        self.component = component
+        self._is_rendering = True
+        self.set_current()
+
+    async def affect_component_did_render(self) -> None:
+        """The component completed a render"""
+        self.unset_current()
+        del self.component
+        self._is_rendering = False
+        self._rendered_atleast_once = True
+        self._current_state_index = 0
+
+    async def affect_layout_did_render(self) -> None:
+        """The layout completed a render"""
+        for start_effect in self._effect_funcs:
+            effect_info = await start_effect()
+            self._effect_infos.add(effect_info)
+        self._effect_funcs.clear()
+
+        if self._schedule_render_later:
+            self._schedule_render()
+        self._schedule_render_later = False
+
+    async def affect_component_will_unmount(self) -> None:
+        """The component is about to be removed from the layout"""
+        for infos in self._effect_infos:
+            infos.stop.set()
+        try:
+            await asyncio.gather(*[i.task for i in self._effect_infos])
+        except Exception:
+            logger.exception("Error during effect cancellation")
+        self._effect_infos.clear()
+
+    def set_current(self) -> None:
+        """Set this hook as the active hook in this thread
+
+        This method is called by a layout before entering the render method
+        of this hook's associated component.
+        """
+        hook_stack = _hook_stack.get()
+        if hook_stack:
+            parent = hook_stack[-1]
+            self._context_providers.update(parent._context_providers)
+        hook_stack.append(self)
+
+    def unset_current(self) -> None:
+        """Unset this hook as the active hook in this thread"""
+        if _hook_stack.get().pop() is not self:
+            raise RuntimeError("Hook stack is in an invalid state")  # nocov
+
+    def _schedule_render(self) -> None:
+        try:
+            self._schedule_render_callback()
+        except Exception:
+            logger.exception(
+                f"Failed to schedule render via {self._schedule_render_callback}"
+            )
+
+
+_EffectStarter: TypeAlias = "Callable[[], Coroutine[None, None, EffectInfo]]"

--- a/src/py/reactpy/reactpy/core/_life_cycle_hook.py
+++ b/src/py/reactpy/reactpy/core/_life_cycle_hook.py
@@ -178,7 +178,7 @@ class LifeCycleHook:
         """The component is about to be removed from the layout"""
         try:
             await asyncio.gather(*[stop() for stop in self._effect_stops])
-        except Exception:
+        except Exception:  # nocov
             logger.exception("Error during effect cancellation")
         finally:
             self._effect_stops.clear()

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -4,7 +4,6 @@ import asyncio
 import inspect
 import warnings
 from collections.abc import Coroutine, Sequence
-from dataclasses import dataclass
 from logging import getLogger
 from types import FunctionType
 from typing import (
@@ -17,19 +16,22 @@ from typing import (
     cast,
     overload,
 )
-from weakref import WeakSet
 
 from typing_extensions import TypeAlias
 
 from reactpy.config import REACTPY_DEBUG_MODE
-from reactpy.core._thread_local import ThreadLocal
-from reactpy.core.types import ComponentType, Key, State, VdomDict
+from reactpy.core._life_cycle_hook import (
+    Context,
+    ContextProvider,
+    EffectInfo,
+    current_hook,
+)
+from reactpy.core.types import Key, State
 from reactpy.utils import Ref
 
 if not TYPE_CHECKING:
     # make flake8 think that this variable exists
     ellipsis = type(...)
-
 
 __all__ = [
     "use_state",
@@ -140,19 +142,19 @@ def use_effect(
     hook = current_hook()
     dependencies = _try_to_infer_closure_values(function, dependencies)
     memoize = use_memo(dependencies=dependencies)
-    effect_info: Ref[_EffectInfo | None] = use_ref(None)
+    effect_info: Ref[EffectInfo | None] = use_ref(None)
 
     def add_effect(function: _EffectFunc) -> None:
         effect = _cast_async_effect(function)
 
-        async def create_effect_task() -> _EffectInfo:
+        async def create_effect_task() -> EffectInfo:
             if effect_info.current is not None:
                 last_effect_info = effect_info.current
                 last_effect_info.stop.set()
                 await last_effect_info.task
 
             stop = asyncio.Event()
-            info = _EffectInfo(asyncio.create_task(effect(stop)), stop)
+            info = EffectInfo(asyncio.create_task(effect(stop)), stop)
             effect_info.current = info
             return info
 
@@ -260,18 +262,6 @@ def create_context(default_value: _Type) -> Context[_Type]:
     return context
 
 
-class Context(Protocol[_Type]):
-    """Returns a :class:`ContextProvider` component"""
-
-    def __call__(
-        self,
-        *children: Any,
-        value: _Type = ...,
-        key: Key | None = ...,
-    ) -> ContextProvider[_Type]:
-        ...
-
-
 def use_context(context: Context[_Type]) -> _Type:
     """Get the current value for the given context type.
 
@@ -291,27 +281,6 @@ def use_context(context: Context[_Type]) -> _Type:
         return cast(_Type, context.__kwdefaults__["value"])
 
     return provider._value
-
-
-class ContextProvider(Generic[_Type]):
-    def __init__(
-        self,
-        *children: Any,
-        value: _Type,
-        key: Key | None,
-        type: Context[_Type],
-    ) -> None:
-        self.children = children
-        self.key = key
-        self.type = type
-        self._value = value
-
-    def render(self) -> VdomDict:
-        current_hook().set_context_provider(self)
-        return {"tagName": "", "children": self.children}
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.type})"
 
 
 _ActionType = TypeVar("_ActionType")
@@ -528,209 +497,6 @@ def _try_to_infer_closure_values(
             return None
     else:
         return values
-
-
-def current_hook() -> LifeCycleHook:
-    """Get the current :class:`LifeCycleHook`"""
-    hook_stack = _hook_stack.get()
-    if not hook_stack:
-        msg = "No life cycle hook is active. Are you rendering in a layout?"
-        raise RuntimeError(msg)
-    return hook_stack[-1]
-
-
-_hook_stack: ThreadLocal[list[LifeCycleHook]] = ThreadLocal(list)
-
-
-class LifeCycleHook:
-    """Defines the life cycle of a layout component.
-
-    Components can request access to their own life cycle events and state through hooks
-    while :class:`~reactpy.core.proto.LayoutType` objects drive drive the life cycle
-    forward by triggering events and rendering view changes.
-
-    Example:
-
-        If removed from the complexities of a layout, a very simplified full life cycle
-        for a single component with no child components would look a bit like this:
-
-        .. testcode::
-
-            from reactpy.core.hooks import (
-                current_hook,
-                LifeCycleHook,
-                COMPONENT_DID_RENDER_EFFECT,
-            )
-
-
-            # this function will come from a layout implementation
-            schedule_render = lambda: ...
-
-            # --- start life cycle ---
-
-            hook = LifeCycleHook(schedule_render)
-
-            # --- start render cycle ---
-
-            component = ...
-            await hook.affect_component_will_render(component)
-            try:
-                # render the component
-                ...
-
-                # the component may access the current hook
-                assert current_hook() is hook
-
-                # and save state or add effects
-                current_hook().use_state(lambda: ...)
-                current_hook().add_effect(COMPONENT_DID_RENDER_EFFECT, lambda: ...)
-            finally:
-                await hook.affect_component_did_render()
-
-            # This should only be called after the full set of changes associated with a
-            # given render have been completed.
-            await hook.affect_layout_did_render()
-
-            # Typically an event occurs and a new render is scheduled, thus beginning
-            # the render cycle anew.
-            hook.schedule_render()
-
-
-            # --- end render cycle ---
-
-            hook.affect_component_will_unmount()
-            del hook
-
-            # --- end render cycle ---
-    """
-
-    __slots__ = (
-        "__weakref__",
-        "_context_providers",
-        "_current_state_index",
-        "_effect_funcs",
-        "_effect_infos",
-        "_is_rendering",
-        "_rendered_atleast_once",
-        "_schedule_render_callback",
-        "_schedule_render_later",
-        "_state",
-        "component",
-    )
-
-    component: ComponentType
-
-    def __init__(
-        self,
-        schedule_render: Callable[[], None],
-    ) -> None:
-        self._context_providers: dict[Context[Any], ContextProvider[Any]] = {}
-        self._schedule_render_callback = schedule_render
-        self._schedule_render_later = False
-        self._is_rendering = False
-        self._rendered_atleast_once = False
-        self._current_state_index = 0
-        self._state: tuple[Any, ...] = ()
-        self._effect_funcs: list[_EffectStarter] = []
-        self._effect_infos: WeakSet[_EffectInfo] = WeakSet()
-
-    def schedule_render(self) -> None:
-        if self._is_rendering:
-            self._schedule_render_later = True
-        else:
-            self._schedule_render()
-
-    def use_state(self, function: Callable[[], _Type]) -> _Type:
-        if not self._rendered_atleast_once:
-            # since we're not initialized yet we're just appending state
-            result = function()
-            self._state += (result,)
-        else:
-            # once finalized we iterate over each succesively used piece of state
-            result = self._state[self._current_state_index]
-        self._current_state_index += 1
-        return result
-
-    def add_effect(self, start_effect: _EffectStarter) -> None:
-        """Trigger a function on the occurrence of the given effect type"""
-        self._effect_funcs.append(start_effect)
-
-    def set_context_provider(self, provider: ContextProvider[Any]) -> None:
-        self._context_providers[provider.type] = provider
-
-    def get_context_provider(
-        self, context: Context[_Type]
-    ) -> ContextProvider[_Type] | None:
-        return self._context_providers.get(context)
-
-    async def affect_component_will_render(self, component: ComponentType) -> None:
-        """The component is about to render"""
-        self.component = component
-        self._is_rendering = True
-        self.set_current()
-
-    async def affect_component_did_render(self) -> None:
-        """The component completed a render"""
-        self.unset_current()
-        del self.component
-        self._is_rendering = False
-        self._rendered_atleast_once = True
-        self._current_state_index = 0
-
-    async def affect_layout_did_render(self) -> None:
-        """The layout completed a render"""
-        for start_effect in self._effect_funcs:
-            effect_info = await start_effect()
-            self._effect_infos.add(effect_info)
-        self._effect_funcs.clear()
-
-        if self._schedule_render_later:
-            self._schedule_render()
-        self._schedule_render_later = False
-
-    async def affect_component_will_unmount(self) -> None:
-        """The component is about to be removed from the layout"""
-        for infos in self._effect_infos:
-            infos.stop.set()
-        try:
-            await asyncio.gather(*[i.task for i in self._effect_infos])
-        except Exception:
-            logger.exception("Error during effect cancellation")
-        self._effect_infos.clear()
-
-    def set_current(self) -> None:
-        """Set this hook as the active hook in this thread
-
-        This method is called by a layout before entering the render method
-        of this hook's associated component.
-        """
-        hook_stack = _hook_stack.get()
-        if hook_stack:
-            parent = hook_stack[-1]
-            self._context_providers.update(parent._context_providers)
-        hook_stack.append(self)
-
-    def unset_current(self) -> None:
-        """Unset this hook as the active hook in this thread"""
-        if _hook_stack.get().pop() is not self:
-            raise RuntimeError("Hook stack is in an invalid state")  # nocov
-
-    def _schedule_render(self) -> None:
-        try:
-            self._schedule_render_callback()
-        except Exception:
-            logger.exception(
-                f"Failed to schedule render via {self._schedule_render_callback}"
-            )
-
-
-_EffectStarter: TypeAlias = "Callable[[], Coroutine[None, None, _EffectInfo]]"
-
-
-@dataclass(frozen=True)
-class _EffectInfo:
-    task: asyncio.Task[None]
-    stop: asyncio.Event
 
 
 def strictly_equal(x: Any, y: Any) -> bool:

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -191,6 +191,7 @@ class Effect:
             cleanup = None
 
         if cleanup is not None:
+            # backwards compat for async cleanup in Python<3.11
             try:
                 await cleanup
             except Exception:

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -188,8 +188,6 @@ class Effect:
         self._stop.set()
         try:
             cleanup = await self.task
-        except CancelledError:
-            pass
         except Exception:
             logger.exception("Error while stopping effect")
 

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -155,16 +155,18 @@ def use_effect(
     def add_effect(function: _Effect) -> None:
         effect_func = _cast_async_effect(function)
 
-        async def start_effect() -> Callable:
+        async def start_effect() -> StopEffect:
             if stop_last_effect.current is not None:
                 await stop_last_effect.current()
 
             stop = Event()
 
-            async def run_effect() -> StopEffect:
+            async def run_effect() -> None:
                 effect_gen = effect_func()
                 # start running the effect
-                effect_task = create_task(effect_gen.asend(None))
+                effect_task = create_task(
+                    cast(Coroutine[None, None, None], effect_gen.asend(None))
+                )
                 # wait for re-render or unmount
                 await stop.wait()
                 # signal effect to stop (no-op if already complete)

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -572,10 +572,8 @@ class LifeCycleHook:
 
             # --- start render cycle ---
 
-            hook.affect_component_will_render(...)
-
-            hook.set_current()
-
+            component = ...
+            await hook.affect_component_will_render(component)
             try:
                 # render the component
                 ...
@@ -587,13 +585,11 @@ class LifeCycleHook:
                 current_hook().use_state(lambda: ...)
                 current_hook().add_effect(COMPONENT_DID_RENDER_EFFECT, lambda: ...)
             finally:
-                hook.unset_current()
-
-            hook.affect_component_did_render()
+                await hook.affect_component_did_render()
 
             # This should only be called after the full set of changes associated with a
             # given render have been completed.
-            hook.affect_layout_did_render()
+            await hook.affect_layout_did_render()
 
             # Typically an event occurs and a new render is scheduled, thus beginning
             # the render cycle anew.

--- a/src/py/reactpy/reactpy/core/layout.py
+++ b/src/py/reactpy/reactpy/core/layout.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 from weakref import ref as weakref
 
 from reactpy.config import REACTPY_CHECK_VDOM_SPEC, REACTPY_DEBUG_MODE
-from reactpy.core.hooks import LifeCycleHook
+from reactpy.core._life_cycle_hook import LifeCycleHook
 from reactpy.core.types import (
     ComponentType,
     EventHandlerDict,

--- a/src/py/reactpy/reactpy/core/types.py
+++ b/src/py/reactpy/reactpy/core/types.py
@@ -20,6 +20,7 @@ from typing import (
 from typing_extensions import TypeAlias, TypedDict
 
 _Type = TypeVar("_Type")
+_Type_invariant = TypeVar("_Type_invariant", covariant=False)
 
 
 if TYPE_CHECKING or sys.version_info < (3, 9) or sys.version_info >= (3, 11):
@@ -233,3 +234,26 @@ class LayoutEventMessage(TypedDict):
     """The ID of the event handler."""
     data: Sequence[Any]
     """A list of event data passed to the event handler."""
+
+
+class Context(Protocol[_Type_invariant]):
+    """Returns a :class:`ContextProvider` component"""
+
+    def __call__(
+        self,
+        *children: Any,
+        value: _Type_invariant = ...,
+        key: Key | None = ...,
+    ) -> ContextProviderType[_Type_invariant]:
+        ...
+
+
+class ContextProviderType(ComponentType, Protocol[_Type]):
+    """A component which provides a context value to its children"""
+
+    type: Context[_Type]
+    """The context type"""
+
+    @property
+    def value(self) -> _Type:
+        "Current context value"

--- a/src/py/reactpy/reactpy/testing/common.py
+++ b/src/py/reactpy/reactpy/testing/common.py
@@ -13,8 +13,8 @@ from weakref import ref
 from typing_extensions import ParamSpec
 
 from reactpy.config import REACTPY_TESTING_DEFAULT_TIMEOUT, REACTPY_WEB_MODULES_DIR
+from reactpy.core._life_cycle_hook import LifeCycleHook, current_hook
 from reactpy.core.events import EventHandler, to_event_handler_function
-from reactpy.core.hooks import LifeCycleHook, current_hook
 
 
 def clear_reactpy_web_modules_dir() -> None:

--- a/src/py/reactpy/reactpy/types.py
+++ b/src/py/reactpy/reactpy/types.py
@@ -6,10 +6,10 @@
 
 from reactpy.backend.types import BackendImplementation, Connection, Location
 from reactpy.core.component import Component
-from reactpy.core.hooks import Context
 from reactpy.core.types import (
     ComponentConstructor,
     ComponentType,
+    Context,
     EventHandlerDict,
     EventHandlerFunc,
     EventHandlerMapping,

--- a/src/py/reactpy/tests/conftest.py
+++ b/src/py/reactpy/tests/conftest.py
@@ -8,7 +8,7 @@ from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from playwright.async_api import async_playwright
 
-from reactpy.config import REACTPY_TESTING_DEFAULT_TIMEOUT
+from reactpy.config import REACTPY_CONCURRENT_RENDERING, REACTPY_TESTING_DEFAULT_TIMEOUT
 from reactpy.testing import (
     BackendFixture,
     DisplayFixture,
@@ -25,6 +25,9 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         help="Open a browser window when running web-based tests",
     )
+
+
+REACTPY_CONCURRENT_RENDERING.current = True
 
 
 @pytest.fixture

--- a/src/py/reactpy/tests/conftest.py
+++ b/src/py/reactpy/tests/conftest.py
@@ -15,7 +15,7 @@ from reactpy.testing import (
     capture_reactpy_logs,
     clear_reactpy_web_modules_dir,
 )
-from tests.tooling.loop import open_event_loop
+from tests.tooling.concurrency import open_event_loop
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/src/py/reactpy/tests/test_client.py
+++ b/src/py/reactpy/tests/test_client.py
@@ -42,7 +42,7 @@ async def test_automatic_reconnect(browser: Browser):
         incr = await page.wait_for_selector("#incr")
 
         for i in range(3):
-            assert (await count.get_attribute("data-count")) == str(i)
+            await poll(count.get_attribute, "data-count").until_equals(str(i))
             await incr.click()
 
     # the server is disconnected but the last view state is still shown
@@ -102,7 +102,9 @@ async def test_style_can_be_changed(display: DisplayFixture):
 
     for color in ["blue", "red"] * 2:
         await button.click()
-        assert (await _get_style(button))["background-color"] == color
+        await poll(_get_style, button).until(
+            lambda style, c=color: style["background-color"] == c
+        )
 
 
 async def _get_style(element):

--- a/src/py/reactpy/tests/test_core/test_hooks.py
+++ b/src/py/reactpy/tests/test_core/test_hooks.py
@@ -5,7 +5,8 @@ import pytest
 import reactpy
 from reactpy import html
 from reactpy.config import REACTPY_DEBUG_MODE
-from reactpy.core.hooks import LifeCycleHook, strictly_equal
+from reactpy.core._life_cycle_hook import LifeCycleHook
+from reactpy.core.hooks import strictly_equal
 from reactpy.core.layout import Layout
 from reactpy.testing import DisplayFixture, HookCatcher, assert_reactpy_did_log, poll
 from reactpy.testing.logs import assert_reactpy_did_not_log

--- a/src/py/reactpy/tests/test_core/test_layout.py
+++ b/src/py/reactpy/tests/test_core/test_layout.py
@@ -20,6 +20,7 @@ from reactpy.testing import (
     assert_reactpy_did_log,
     capture_reactpy_logs,
 )
+from reactpy.testing.common import poll
 from reactpy.utils import Ref
 from tests.tooling import select
 from tests.tooling.common import event_message, update_message
@@ -828,20 +829,28 @@ async def test_elements_and_components_with_the_same_key_can_be_interchanged():
 
         return reactpy.html.div(name)
 
+    poll_effects = poll(lambda: effects)
+
     async with reactpy.Layout(Root()) as layout:
         await layout.render()
 
-        assert effects == ["mount x"]
+        await poll_effects.until_equals(
+            ["mount x"],
+        )
 
         set_toggle.current()
         await layout.render()
 
-        assert effects == ["mount x", "unmount x", "mount y"]
+        await poll_effects.until_equals(
+            ["mount x", "unmount x", "mount y"],
+        )
 
         set_toggle.current()
         await layout.render()
 
-        assert effects == ["mount x", "unmount x", "mount y", "unmount y", "mount x"]
+        await poll_effects.until_equals(
+            ["mount x", "unmount x", "mount y", "unmount y", "mount x"],
+        )
 
 
 async def test_layout_does_not_copy_element_children_by_key():

--- a/src/py/reactpy/tests/test_core/test_serve.py
+++ b/src/py/reactpy/tests/test_core/test_serve.py
@@ -5,11 +5,13 @@ from typing import Any
 from jsonpointer import set_pointer
 
 import reactpy
+from reactpy.core.hooks import use_effect
 from reactpy.core.layout import Layout
 from reactpy.core.serve import serve_layout
 from reactpy.core.types import LayoutUpdateMessage
 from reactpy.testing import StaticEventHandler
 from tests.tooling.common import event_message
+from tests.tooling.concurrency import WaitForEvent
 
 EVENT_NAME = "on_event"
 STATIC_EVENT_HANDLER = StaticEventHandler()
@@ -96,9 +98,10 @@ async def test_dispatch():
 
 
 async def test_dispatcher_handles_more_than_one_event_at_a_time():
-    block_and_never_set = asyncio.Event()
-    will_block = asyncio.Event()
-    second_event_did_execute = asyncio.Event()
+    did_render = WaitForEvent()
+    block_and_never_set = WaitForEvent()
+    will_block = WaitForEvent()
+    second_event_did_execute = WaitForEvent()
 
     blocked_handler = StaticEventHandler()
     non_blocked_handler = StaticEventHandler()
@@ -113,6 +116,10 @@ async def test_dispatcher_handles_more_than_one_event_at_a_time():
         @non_blocked_handler.use
         async def handle_event():
             second_event_did_execute.set()
+
+        @use_effect
+        def set_did_render():
+            did_render.set()
 
         return reactpy.html.div(
             reactpy.html.button({"on_click": block_forever}),
@@ -129,11 +136,12 @@ async def test_dispatcher_handles_more_than_one_event_at_a_time():
             recv_queue.get,
         )
     )
+    try:
+        await did_render.wait()
+        await recv_queue.put(event_message(blocked_handler.target))
+        await will_block.wait()
 
-    await recv_queue.put(event_message(blocked_handler.target))
-    await will_block.wait()
-
-    await recv_queue.put(event_message(non_blocked_handler.target))
-    await second_event_did_execute.wait()
-
-    task.cancel()
+        await recv_queue.put(event_message(non_blocked_handler.target))
+        await second_event_did_execute.wait()
+    finally:
+        task.cancel()

--- a/src/py/reactpy/tests/tooling/concurrency.py
+++ b/src/py/reactpy/tests/tooling/concurrency.py
@@ -1,0 +1,98 @@
+import asyncio
+import threading
+import time
+from asyncio import Event, wait_for
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from reactpy.config import REACTPY_TESTING_DEFAULT_TIMEOUT
+
+
+class WaitForEvent(Event):
+    """Event where the wait method has a timeout."""
+
+    async def wait(self, timeout: float = REACTPY_TESTING_DEFAULT_TIMEOUT.current):
+        return await wait_for(super().wait(), timeout=timeout)
+
+
+@contextmanager
+def open_event_loop(as_current: bool = True) -> Iterator[asyncio.AbstractEventLoop]:
+    """Open a new event loop and cleanly stop it
+
+    Args:
+        as_current: whether to make this loop the current loop in this thread
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        if as_current:
+            asyncio.set_event_loop(loop)
+        loop.set_debug(True)
+        yield loop
+    finally:
+        try:
+            _cancel_all_tasks(loop, as_current)
+            if as_current:
+                loop.run_until_complete(
+                    wait_for(
+                        loop.shutdown_asyncgens(),
+                        REACTPY_TESTING_DEFAULT_TIMEOUT.current,
+                    )
+                )
+                loop.run_until_complete(
+                    wait_for(
+                        loop.shutdown_default_executor(),
+                        REACTPY_TESTING_DEFAULT_TIMEOUT.current,
+                    )
+                )
+        finally:
+            if as_current:
+                asyncio.set_event_loop(None)
+            start = time.time()
+            while loop.is_running():
+                if (time.time() - start) > REACTPY_TESTING_DEFAULT_TIMEOUT.current:
+                    msg = f"Failed to stop loop after {REACTPY_TESTING_DEFAULT_TIMEOUT.current} seconds"
+                    raise TimeoutError(msg)
+                time.sleep(0.1)
+            loop.close()
+
+
+def _cancel_all_tasks(loop: asyncio.AbstractEventLoop, is_current: bool) -> None:
+    to_cancel = asyncio.all_tasks(loop)
+    if not to_cancel:
+        return
+
+    done = threading.Event()
+    count = len(to_cancel)
+
+    def one_task_finished(future):
+        nonlocal count
+        count -= 1
+        if count == 0:
+            done.set()
+
+    for task in to_cancel:
+        loop.call_soon_threadsafe(task.cancel)
+        task.add_done_callback(one_task_finished)
+
+    if is_current:
+        loop.run_until_complete(
+            wait_for(
+                asyncio.gather(*to_cancel, return_exceptions=True),
+                REACTPY_TESTING_DEFAULT_TIMEOUT.current,
+            )
+        )
+    elif not done.wait(timeout=3):  # user was responsible for cancelling all tasks
+        msg = "Could not stop event loop in time"
+        raise TimeoutError(msg)
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler(
+                {
+                    "message": "unhandled exception during event loop shutdown",
+                    "exception": task.exception(),
+                    "task": task,
+                }
+            )


### PR DESCRIPTION
<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

Closes: #956

## Solution

Async effects now accept a "stop" `Event` that is set when an effect needs to be re-run or a component is unmounting. The next effect will only run when the last effect has exited.

```python
@use_effect
async def my_effect(stop):
    ... # do work
    await stop.wait()
    ... # do cleanup
```

Implementing this same behavior using sync effects is quite challenging:

```python
import threading, asyncio
from reactpy import use_effect, use_ref


def use_async_effect(func):
    thread = use_ref(None)

    @use_effect
    def my_effect():
        if thread.current is not None:
            # wait for last effect to complete
            thread.current.join()

        loop = stop = None
        started = threading.Event()

        def thread_target():
            async def wrapper():
                nonlocal loop, stop
                loop = asyncio.get_running_loop()
                stop = asyncio.Event()
                started.set()
                await func(stop)

            asyncio.run(wrapper())

        # start effect
        thread.current = threading.Thread(target=thread_target, daemon=True)
        thread.current.start()
        started.wait()

        # register stop callback
        return lambda: loop.call_soon_threadsafe(stop.set)
```

To achieve this without requiring an implementation similar to the above, we've asyncified the internals of `Layout`. This has the side-effect of allowing other things to happen while the `Layout` is rendering (e.g. receive events, or allowing the server to respond to other requests). This potentially comes at the cost of rendering speed. For example, if a user is spamming the server with events renders may be interrupted in order to respond to them.

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
