### PR TITLE
need to copy scheme from base url

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,9 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-Nothing yet...
+**Fixed**
+
+- :pull:`1118` - `module_from_template` is broken with a recent release of `requests`
 
 
 v1.0.2

--- a/src/py/reactpy/reactpy/web/utils.py
+++ b/src/py/reactpy/reactpy/web/utils.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from pathlib import Path, PurePosixPath
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import requests
 
@@ -130,7 +130,11 @@ def resolve_module_exports_from_source(
 
 def _resolve_relative_url(base_url: str, rel_url: str) -> str:
     if not rel_url.startswith("."):
-        return rel_url
+        if rel_url.startswith("/"):
+            # copy scheme and hostname from base_url
+            return urlunparse(urlparse(base_url)[:2] + urlparse(rel_url)[2:])
+        else:
+            return rel_url
 
     base_url = base_url.rsplit("/", 1)[0]
 

--- a/temp.py
+++ b/temp.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+
+from reactpy import html, web
+from reactpy.backend.fastapi import configure
+
+mui = web.module_from_template(
+    "react",
+    "@mui/x-date-pickers",
+    fallback="please wait loading...",
+)
+
+
+# Create calendar with material ui
+DatePicker = web.export(mui, "DatePicker")
+
+
+def Mycalender():
+    return html.div(
+        DatePicker(
+            {
+                "label": "Basic date picker",
+            },
+            "my calender",
+        ),
+    )
+
+
+app = FastAPI()
+configure(app, Mycalender)


### PR DESCRIPTION
<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

Tests are broken (likely due to an update to `requests`). URL resolution in `module_from_template` is missing a scheme and hostname.

## Solution

Copy the base URL scheme and hostname when resolving relative URLs.

## Checklist

- [x] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
