### PR TITLE
Fix flask backend mimetype for modules

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -26,6 +26,7 @@ Unreleased
 **Fixed**
 
 - :pull:`1118` - `module_from_template` is broken with a recent release of `requests`
+- :pull:`1131` - `module_from_template` did not work when using Flask backend
 
 
 v1.0.2

--- a/src/py/reactpy/reactpy/backend/flask.py
+++ b/src/py/reactpy/reactpy/backend/flask.py
@@ -165,7 +165,7 @@ def _setup_common_routes(
 
     @api_blueprint.route(f"/{MODULES_PATH.name}/<path:path>")
     def send_modules_dir(path: str = "") -> Any:
-        return send_file(safe_web_modules_dir_path(path))
+        return send_file(safe_web_modules_dir_path(path), mimetype="text/javascript")
 
     index_html = read_client_index_html(options)
 


### PR DESCRIPTION
<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

When running reactpy with Flask backend, `web.module_from_template` resulted an error (in the browser) about wrong mimetype. In example:
```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "application/octet-stream". Strict MIME type checking is enforced for module scripts per HTML spec.

Uncaught (in promise) TypeError: Failed to fetch dynamically imported module: http://localhost:8000/_reactpy/modules/__from_template__/@material-ui/core@4.12.4.4.js
```

## Solution

Explicitly add the mimetype when using `send_file`

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
