### PR TITLE
Add <marquee> element

### DIFF
--- a/src/py/reactpy/reactpy/html.py
+++ b/src/py/reactpy/reactpy/html.py
@@ -281,6 +281,7 @@ __all__ = (
     "var",
     "video",
     "wbr",
+    "marquee",
 )
 
 
@@ -402,6 +403,9 @@ math = make_vdom_constructor("math")
 # Scripting
 canvas = make_vdom_constructor("canvas")
 noscript = make_vdom_constructor("noscript")
+
+# Other
+marquee = make_vdom_constructor("marquee")
 
 
 def _script(


### PR DESCRIPTION
This commit simply adds the option to use the marquee element in reactpy. While yes, the marquee element has been deprecated, I think that it would be best to allow web developers the freedom to use this element even when it is deprecated. Also the marquee element is still usable in all major browsers.

<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

The issue was that I was unable to use the marquee element in a project I was working on.

## Solution

I simply added the marquee element in html.py

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
