### PR TITLE
better async effects

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -34,6 +34,11 @@ Unreleased
   experimental feature by setting `REACTPY_ASYNC_RENDERING=true`. This should improve
   the overall responsiveness of your app, particularly when handling larger renders
   that would otherwise block faster renders from being processed.
+- :pull:`1169` - Sync and async effects can now be defined as generators which ``yield``
+  control back to ReactPy until they need to be cleaned up. Previously async effects
+  were only allowed to have synchronous cleanup cleanup. This now allows them to be
+  cleaned up asynchronously. See the :ref:`updated documentation <Use Effect>` for more
+  information. 
 
 v1.0.2
 ------

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -16,8 +16,10 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Optional,
     Protocol,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -100,14 +102,14 @@ class _CurrentState(Generic[_Type]):
 
 
 _SyncGeneratorEffect = Callable[[], Generator[None, None, None]]
-_SyncFunctionEffect = Callable[[], Callable[[], None] | None]
-_SyncEffect = _SyncGeneratorEffect | _SyncFunctionEffect
+_SyncFunctionEffect = Callable[[], Optional[Callable[[], None]]]
+_SyncEffect = Union[_SyncGeneratorEffect, _SyncFunctionEffect]
 
 _AsyncGeneratorEffect = Callable[[], AsyncGenerator[None, None]]
-_AsyncFunctionEffect = Callable[[], Coroutine[None, None, Callable[[], None] | None]]
-_AsyncEffect = _AsyncGeneratorEffect | _AsyncFunctionEffect
+_AsyncFunctionEffect = Callable[[], Coroutine[None, None, Optional[Callable[[], None]]]]
+_AsyncEffect = Union[_AsyncGeneratorEffect, _AsyncFunctionEffect]
 
-_Effect = _SyncEffect | _AsyncEffect
+_Effect = Union[_SyncEffect, _AsyncEffect]
 
 
 @overload

--- a/src/py/reactpy/tests/test_core/test_hooks.py
+++ b/src/py/reactpy/tests/test_core/test_hooks.py
@@ -1,4 +1,4 @@
-from asyncio import CancelledError, create_task, sleep, wait_for
+from asyncio import CancelledError, TimeoutError, create_task, sleep, wait_for
 from asyncio import Event as EventNoTimeout
 
 import pytest
@@ -1213,7 +1213,7 @@ async def test_use_state_compares_with_strict_equality(get_value):
 @pytest.mark.parametrize("get_value", STRICT_EQUALITY_VALUE_CONSTRUCTORS)
 async def test_use_effect_compares_with_strict_equality(get_value):
     effect_count = reactpy.Ref(0)
-    value = reactpy.Ref("string")
+    value = reactpy.Ref(get_value())
     hook = HookCatcher()
 
     @reactpy.component
@@ -1226,7 +1226,7 @@ async def test_use_effect_compares_with_strict_equality(get_value):
     async with reactpy.Layout(SomeComponent()) as layout:
         await layout.render()
         assert effect_count.current == 1
-        value.current = "string"  # new string instance but same value
+        value.current = get_value()
         hook.latest.schedule_render()
         await layout.render()
         # effect does not trigger


### PR DESCRIPTION
<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

Closes: https://github.com/reactive-python/reactpy/issues/956

## Solution

Effects can now be defines as sync or async generators (more info in [the docs](https://github.com/rmorshea/reactpy/blob/af162be9960751c2dda9be7e7b97d367597df111/docs/source/reference/hooks-api.rst?plain=1#L87-L241)):

```python
@use_effect
def my_effect():
    conn = open_connection()
    try:
        # do something with the connection
        yield
    finally:
        conn.close()

@use_effect
async def my_effect():
    conn = await open_connection()
    try:
        # do something with the connection
        yield
    finally:
        await conn.close()
```

_Note: this contains a subset of the changes originally created in https://github.com/reactive-python/reactpy/pull/1093_

## Checklist

- [x] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
