### PR TITLE
Skip rendering None in all situations

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -41,10 +41,9 @@ Unreleased
   the string ``"None"``. Now ``None`` will not render at all. This is consistent with
   how ``None`` is handled when returned from components. It also makes it easier to
   conditionally render elements. For example, previously you would have needed to use a
-  fragment to conditionally render an element (e.g.
-  ``something if condition else html._()``). Now you can write:
-  ``something if condition else None``. The latter now has the minor performance
-  advantage of not needing to create and render a fragment.
+  fragment to conditionally render an element by writing
+  ``something if condition else html._()``. Now you can simply write
+  ``something if condition else None``.
 
 
 v1.0.2

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -45,6 +45,12 @@ Unreleased
   ``something if condition else html._()``. Now you can simply write
   ``something if condition else None``.
 
+**Deprecated**
+
+- :pull:`1171` - The ``Stop`` exception. Recent releases of ``anyio`` have made this
+  exception difficult to use since it now raises an ``ExceptionGroup``. This exception
+  was primarily used for internal testing purposes and so is now deprecated.
+
 
 v1.0.2
 ------

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -35,6 +35,18 @@ Unreleased
   the overall responsiveness of your app, particularly when handling larger renders
   that would otherwise block faster renders from being processed.
 
+**Changed**
+
+- :pull:`1171` - Previously ``None``, when present in an HTML element, would render as
+  the string ``"None"``. Now ``None`` will not render at all. This is consistent with
+  how ``None`` is handled when returned from components. It also makes it easier to
+  conditionally render elements. For example, previously you would have needed to use a
+  fragment to conditionally render an element (e.g.
+  ``something if condition else html._()``). Now you can write:
+  ``something if condition else None``. The latter now has the minor performance
+  advantage of not needing to create and render a fragment.
+
+
 v1.0.2
 ------
 

--- a/src/py/reactpy/pyproject.toml
+++ b/src/py/reactpy/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+  "exceptiongroup >=1.0",
   "typing-extensions >=3.10",
   "mypy-extensions >=0.4.3",
   "anyio >=3",

--- a/src/py/reactpy/reactpy/__init__.py
+++ b/src/py/reactpy/reactpy/__init__.py
@@ -16,7 +16,6 @@ from reactpy.core.hooks import (
     use_state,
 )
 from reactpy.core.layout import Layout
-from reactpy.core.serve import Stop
 from reactpy.core.vdom import vdom
 from reactpy.utils import Ref, html_to_vdom, vdom_to_html
 

--- a/src/py/reactpy/reactpy/backend/starlette.py
+++ b/src/py/reactpy/reactpy/backend/starlette.py
@@ -166,7 +166,7 @@ def _setup_single_view_dispatcher_route(
                 if isinstance(e, WebSocketDisconnect):
                     logger.info(f"WebSocket disconnect: {e.code}")
                     break
-            else:
+            else:  # nocov
                 raise
 
     app.add_websocket_route(str(STREAM_PATH), model_stream)

--- a/src/py/reactpy/reactpy/backend/starlette.py
+++ b/src/py/reactpy/reactpy/backend/starlette.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from exceptiongroup import BaseExceptionGroup
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -137,8 +138,6 @@ def _make_index_route(options: Options) -> Callable[[Request], Awaitable[HTMLRes
 def _setup_single_view_dispatcher_route(
     options: Options, app: Starlette, component: RootComponentConstructor
 ) -> None:
-    @app.websocket_route(str(STREAM_PATH))
-    @app.websocket_route(f"{STREAM_PATH}/{{path:path}}")
     async def model_stream(socket: WebSocket) -> None:
         await socket.accept()
         send, recv = _make_send_recv_callbacks(socket)
@@ -162,8 +161,16 @@ def _setup_single_view_dispatcher_route(
                 send,
                 recv,
             )
-        except WebSocketDisconnect as error:
-            logger.info(f"WebSocket disconnect: {error.code}")
+        except BaseExceptionGroup as egroup:
+            for e in egroup.exceptions:
+                if isinstance(e, WebSocketDisconnect):
+                    logger.info(f"WebSocket disconnect: {e.code}")
+                    break
+            else:
+                raise
+
+    app.add_websocket_route(str(STREAM_PATH), model_stream)
+    app.add_websocket_route(f"{STREAM_PATH}/{{path:path}}", model_stream)
 
 
 def _make_send_recv_callbacks(

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable
 from logging import getLogger
 from typing import Callable
+from warnings import warn
 
 from anyio import create_task_group
 from anyio.abc import TaskGroup
@@ -24,7 +25,9 @@ The event will then trigger an :class:`reactpy.core.proto.EventHandlerType` in a
 
 
 class Stop(BaseException):
-    """Stop serving changes and events
+    """Deprecated
+
+    Stop serving changes and events
 
     Raising this error will tell dispatchers to gracefully exit. Typically this is
     called by code running inside a layout to tell it to stop rendering.
@@ -42,7 +45,12 @@ async def serve_layout(
             async with create_task_group() as task_group:
                 task_group.start_soon(_single_outgoing_loop, layout, send)
                 task_group.start_soon(_single_incoming_loop, task_group, layout, recv)
-        except Stop:
+        except Stop:  # nocov
+            warn(
+                "The Stop exception is deprecated and will be removed in a future version",
+                UserWarning,
+                stacklevel=1,
+            )
             logger.info(f"Stopped serving {layout}")
 
 

--- a/src/py/reactpy/reactpy/core/types.py
+++ b/src/py/reactpy/reactpy/core/types.py
@@ -91,7 +91,7 @@ class LayoutType(Protocol[_Render_co, _Event_contra]):
 VdomAttributes = Mapping[str, Any]
 """Describes the attributes of a :class:`VdomDict`"""
 
-VdomChild: TypeAlias = "ComponentType | VdomDict | str"
+VdomChild: TypeAlias = "ComponentType | VdomDict | str | None | Any"
 """A single child element of a :class:`VdomDict`"""
 
 VdomChildren: TypeAlias = "Sequence[VdomChild] | VdomChild"
@@ -100,14 +100,7 @@ VdomChildren: TypeAlias = "Sequence[VdomChild] | VdomChild"
 
 class _VdomDictOptional(TypedDict, total=False):
     key: Key | None
-    children: Sequence[
-        # recursive types are not allowed yet:
-        # https://github.com/python/mypy/issues/731
-        ComponentType
-        | dict[str, Any]
-        | str
-        | Any
-    ]
+    children: Sequence[ComponentType | VdomChild]
     attributes: VdomAttributes
     eventHandlers: EventHandlerDict
     importSource: ImportSourceDict

--- a/src/py/reactpy/tests/test_core/test_layout.py
+++ b/src/py/reactpy/tests/test_core/test_layout.py
@@ -102,15 +102,6 @@ async def test_simple_layout():
         )
 
 
-async def test_component_can_return_none():
-    @reactpy.component
-    def SomeComponent():
-        return None
-
-    async with reactpy.Layout(SomeComponent()) as layout:
-        assert (await layout.render())["model"] == {"tagName": ""}
-
-
 async def test_nested_component_layout():
     parent_set_state = reactpy.Ref(None)
     child_set_state = reactpy.Ref(None)
@@ -1310,3 +1301,22 @@ async def test_concurrent_renders(concurrent_rendering):
 
         assert child_1_render_count.current == 1
         assert child_2_render_count.current == 1
+
+
+async def test_none_does_not_render():
+    @component
+    def Root():
+        return html.div(None, Child())
+
+    @component
+    def Child():
+        return None
+
+    async with layout_runner(Layout(Root())) as runner:
+        tree = await runner.render()
+        assert tree == {
+            "tagName": "",
+            "children": [
+                {"tagName": "div", "children": [{"tagName": "", "children": []}]}
+            ],
+        }

--- a/src/py/reactpy/tests/test_core/test_serve.py
+++ b/src/py/reactpy/tests/test_core/test_serve.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from collections.abc import Sequence
 from typing import Any
 
@@ -91,6 +92,7 @@ def Counter():
     return reactpy.html.div({EVENT_NAME: handler, "count": count})
 
 
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="ExceptionGroup not available")
 async def test_dispatch():
     events, expected_model = make_events_and_expected_model()
     changes, send, recv = make_send_recv_callbacks(events)

--- a/src/py/reactpy/tests/test_core/test_serve.py
+++ b/src/py/reactpy/tests/test_core/test_serve.py
@@ -18,10 +18,6 @@ EVENT_NAME = "on_event"
 STATIC_EVENT_HANDLER = StaticEventHandler()
 
 
-class StopError(Exception):
-    """Stop the dispatcher"""
-
-
 def make_send_recv_callbacks(events_to_inject):
     changes = []
 
@@ -36,7 +32,7 @@ def make_send_recv_callbacks(events_to_inject):
         changes.append(patch)
         sem.release()
         if not events_to_inject:
-            raise StopError()
+            raise Exception("Stop running")
 
     async def recv():
         await sem.acquire()
@@ -98,7 +94,7 @@ def Counter():
 async def test_dispatch():
     events, expected_model = make_events_and_expected_model()
     changes, send, recv = make_send_recv_callbacks(events)
-    with pytest.raises(StopError):
+    with pytest.raises(ExceptionGroup):
         await asyncio.wait_for(serve_layout(Layout(Counter()), send, recv), 1)
     assert_changes_produce_expected_model(changes, expected_model)
 


### PR DESCRIPTION
<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

Currently the value `None` will render as the string `"None"` when used as a child in VDOM elements. However, when returned by a component it will not render. This inconsistency is confusing for users.

fix #1025

## Solution

We should skip rendering `None` in all cases.


## Checklist

- [X] Tests have been included for all bug fixes or added functionality.
- [X] The `changelog.rst` has been updated with any significant changes.
