### PR TITLE
Fix component decorator eating static type hints

### DIFF
--- a/src/py/reactpy/reactpy/core/component.py
+++ b/src/py/reactpy/reactpy/core/component.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import inspect
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar
 
 from reactpy.core.types import ComponentType, VdomDict
 
+T = TypeVar("T", bound=Callable[..., ComponentType | VdomDict | str | None])
 
 def component(
-    function: Callable[..., ComponentType | VdomDict | str | None]
-) -> Callable[..., Component]:
+    function: T
+) -> T:
     """A decorator for defining a new component.
 
     Parameters:

--- a/src/py/reactpy/reactpy/core/component.py
+++ b/src/py/reactpy/reactpy/core/component.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import inspect
 from functools import wraps
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, ParamSpec
 
 from reactpy.core.types import ComponentType, VdomDict
 
-T = TypeVar("T", bound=Callable[..., ComponentType | VdomDict | str | None])
+T = TypeVar("T", bound=ComponentType | VdomDict | str | None)
+P = ParamSpec("P")
+
 
 def component(
-    function: T
-) -> T:
+    function: Callable[P, T],
+) -> Callable[P, Component]:
     """A decorator for defining a new component.
 
     Parameters:
@@ -26,7 +28,7 @@ def component(
         raise TypeError(msg)
 
     @wraps(function)
-    def constructor(*args: Any, key: Any | None = None, **kwargs: Any) -> Component:
+    def constructor(*args: P.args, key: Any | None = None, **kwargs: P.kwargs) -> Component:
         return Component(function, key, args, kwargs, sig)
 
     return constructor


### PR DESCRIPTION
<sub>By submitting this pull request you agree that all contributions to this project are made under the MIT license.</sub>

## Issues

The `@component` decorator eats type hints so you can't easily see the parameters to your component (just shows up as `...`)

## Solution

This updates the type hinting so that component returns the same things its decorating

## Checklist

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.

![before-after-component-type-fix](https://github.com/reactive-python/reactpy/assets/122519877/4343184b-21d0-4baf-b5f3-a060245f7ebc)

The top screenshot is the current behavior. The bottom is the updated behavior. Note that the top `Component` is reactpy's while the bottom `Component` is my own.