### PR TITLE
Fixes needless custom component recreation (#1195)

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,6 +23,7 @@ Unreleased
 - :pull:`1118` - `module_from_template` is broken with a recent release of `requests`
 - :pull:`1131` - `module_from_template` did not work when using Flask backend
 - :pull:`1200` - Fixed `UnicodeDecodeError` when using `reactpy.web.export`
+- :pull:`1224` - Fixes needless unmounting of JavaScript components during each ReactPy render.
 
 **Added**
 

--- a/src/js/packages/@reactpy/client/src/components.tsx
+++ b/src/js/packages/@reactpy/client/src/components.tsx
@@ -177,7 +177,7 @@ function useForceUpdate() {
 
 function useImportSource(model: ReactPyVdom): MutableRefObject<any> {
   const vdomImportSource = model.importSource;
-
+  const vdomImportSourceJsonString = JSON.stringify(vdomImportSource);
   const mountPoint = useRef<HTMLElement>(null);
   const client = React.useContext(ClientContext);
   const [binding, setBinding] = useState<ImportSourceBinding | null>(null);
@@ -203,7 +203,7 @@ function useImportSource(model: ReactPyVdom): MutableRefObject<any> {
         binding.unmount();
       }
     };
-  }, [client, vdomImportSource, setBinding, mountPoint.current]);
+  }, [client, vdomImportSourceJsonString, setBinding, mountPoint.current]);
 
   // this effect must run every time in case the model has changed
   useEffect(() => {

--- a/src/py/reactpy/reactpy/web/templates/react.js
+++ b/src/py/reactpy/reactpy/web/templates/react.js
@@ -17,11 +17,12 @@ export default ({ children, ...props }) => {
 };
 
 export function bind(node, config) {
+  const root = ReactDOM.createRoot(node);
   return {
     create: (component, props, children) =>
       React.createElement(component, wrapEventHandlers(props), ...children),
-    render: (element) => ReactDOM.render(element, node),
-    unmount: () => ReactDOM.unmountComponentAtNode(node),
+    render: (element) => root.render(element),
+    unmount: () => root.unmount()
   };
 }
 


### PR DESCRIPTION
As detailed in issue #1195, custom components were being needlessly re-created on every re-render. This was due to the `vdomImportSource` (i.e. `model.importSource`) of the custom component being used as a dependency of the `useEffect` function that creates/binds the custom components. Using a JavaScript object (i.e. dictionary) as a dependency was an issue in this case since the object in question was being recreated anew every re-render even though its actual key/value entries were not. 

I initially completely removed `vdomImportSource` from the dependencies, not understanding a use case where it would ever change anyway, but second guessed its importance due to it being there in the first place. I ended up finding [this article](https://profy.dev/article/react-useeffect-with-object-dependency) and opted for their recommended "Approach 4", which is to `JSON.stringify` the object and use that as the dependency instead.

I also went ahead and refactored the `react.js` web template file to use the [new createRoot(...).render() workflow in ReactJS 18](https://react.dev/reference/react-dom/client/createRoot#reference), as mentioned by @rmorshea in the original issue. Although it seems to be working great for me, I'm definitely not a ReactPy nor even a ReactJS expert, so that should definitely be looked over by someone more experienced.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
