### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/.hatch-run.yml
+++ b/.github/workflows/.hatch-run.yml
@@ -41,7 +41,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: "14.x"
+                  node-version: "23.x"
                   registry-url: ${{ inputs.node-registry-url }}
             - name: Pin NPM Version
               run: npm install -g npm@8.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,11 @@ detached = true
 dependencies = [
   "invoke",
   # lint
-  "black==24.1.1",        # Pin lint tools we don't control to avoid breaking changes
-  "ruff==0.0.278",        # Pin lint tools we don't control to avoid breaking changes
+  "black==24.1.1",    # Pin lint tools we don't control to avoid breaking changes
+  "ruff==0.0.278",    # Pin lint tools we don't control to avoid breaking changes
   "toml",
-  "flake8==7.0.0",        # Pin lint tools we don't control to avoid breaking changes
+  "flake8==7.0.0",    # Pin lint tools we don't control to avoid breaking changes
   "flake8-pyproject",
-  "reactpy-flake8 >=0.7",
   # types
   "mypy",
   "types-toml",

--- a/src/py/reactpy/pyproject.toml
+++ b/src/py/reactpy/pyproject.toml
@@ -96,7 +96,6 @@ dependencies = [
   "types-click",
   "types-tornado",
   "types-flask",
-  "pkg_resources; sys_platform != 'win32'",
   "types-requests",
 ]
 

--- a/src/py/reactpy/pyproject.toml
+++ b/src/py/reactpy/pyproject.toml
@@ -12,9 +12,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 keywords = ["react", "javascript", "reactpy", "component"]
-authors = [
-  { name = "Ryan Morshead", email = "ryan.morshead@gmail.com" },
-]
+authors = [{ name = "Ryan Morshead", email = "ryan.morshead@gmail.com" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
@@ -39,10 +37,7 @@ dependencies = [
 [project.optional-dependencies]
 all = ["reactpy[starlette,sanic,fastapi,flask,tornado,testing]"]
 
-starlette = [
-  "starlette >=0.13.6",
-  "uvicorn[standard] >=0.19.0",
-]
+starlette = ["starlette >=0.13.6", "uvicorn[standard] >=0.19.0"]
 sanic = [
   "sanic >=21",
   "sanic-cors",
@@ -50,22 +45,10 @@ sanic = [
   "setuptools",
   "uvicorn[standard] >=0.19.0",
 ]
-fastapi = [
-  "fastapi >=0.63.0",
-  "uvicorn[standard] >=0.19.0",
-]
-flask = [
-  "flask",
-  "markupsafe>=1.1.1,<2.1",
-  "flask-cors",
-  "flask-sock",
-]
-tornado = [
-  "tornado",
-]
-testing = [
-  "playwright",
-]
+fastapi = ["fastapi >=0.63.0", "uvicorn[standard] >=0.19.0"]
+flask = ["flask", "markupsafe>=1.1.1,<2.1", "flask-cors", "flask-sock"]
+tornado = ["tornado"]
+testing = ["playwright"]
 
 [project.urls]
 Source = "https://github.com/reactive-python/reactpy"
@@ -101,22 +84,19 @@ cov-report = [
   # "- coverage combine",
   "coverage report",
 ]
-cov = [
-  "test-cov {args}",
-  "cov-report",
-]
+cov = ["test-cov {args}", "cov-report"]
 
 [tool.hatch.envs.default.env-vars]
-REACTPY_DEBUG_MODE="1"
+REACTPY_DEBUG_MODE = "1"
 
 [tool.hatch.envs.lint]
 features = ["all"]
 dependencies = [
-  "mypy>=1.0.0",
+  "mypy==1.8",
   "types-click",
   "types-tornado",
-  "types-pkg-resources",
   "types-flask",
+  "pkg_resources; sys_platform != 'win32'",
   "types-requests",
 ]
 
@@ -127,13 +107,8 @@ all = ["types"]
 [[tool.hatch.build.hooks.build-scripts.scripts]]
 work_dir = "../../js"
 out_dir = "reactpy/_static"
-commands = [
-  "npm ci",
-  "npm run build"
-]
-artifacts = [
-  "app/dist/"
-]
+commands = ["npm ci", "npm run build"]
+artifacts = ["app/dist/"]
 
 # --- Pytest ---------------------------------------------------------------------------
 
@@ -159,9 +134,7 @@ warn_unused_ignores = true
 source_pkgs = ["reactpy"]
 branch = false
 parallel = false
-omit = [
-  "reactpy/__init__.py",
-]
+omit = ["reactpy/__init__.py"]
 
 [tool.coverage.report]
 fail_under = 100
@@ -174,6 +147,4 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
-omit = [
-    "reactpy/__main__.py",
-]
+omit = ["reactpy/__main__.py"]

--- a/src/py/reactpy/reactpy/_warnings.py
+++ b/src/py/reactpy/reactpy/_warnings.py
@@ -13,7 +13,7 @@ def warn(*args: Any, **kwargs: Any) -> Any:
 
 
 if TYPE_CHECKING:
-    warn = _warn
+    warn = _warn  # noqa: F811
 
 
 def _frame_depth_in_module() -> int:

--- a/src/py/reactpy/reactpy/_warnings.py
+++ b/src/py/reactpy/reactpy/_warnings.py
@@ -13,7 +13,7 @@ def warn(*args: Any, **kwargs: Any) -> Any:
 
 
 if TYPE_CHECKING:
-    warn = _warn  # noqa: F811
+    warn = _warn
 
 
 def _frame_depth_in_module() -> int:

--- a/src/py/reactpy/reactpy/core/events.py
+++ b/src/py/reactpy/reactpy/core/events.py
@@ -109,7 +109,7 @@ class EventHandler:
         self.stop_propagation = stop_propagation
         self.target = target
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         undefined = object()
         for attr in (
             "function",

--- a/src/py/reactpy/reactpy/core/layout.py
+++ b/src/py/reactpy/reactpy/core/layout.py
@@ -89,7 +89,7 @@ class Layout:
 
         return self
 
-    async def __aexit__(self, *exc: Any) -> None:
+    async def __aexit__(self, *exc: object) -> None:
         root_csid = self._root_life_cycle_state_id
         root_model_state = self._model_states_by_life_cycle_state_id[root_csid]
 

--- a/src/py/reactpy/reactpy/utils.py
+++ b/src/py/reactpy/reactpy/utils.py
@@ -43,7 +43,7 @@ class Ref(Generic[_RefValue]):
         self.current = new
         return old
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         try:
             return isinstance(other, Ref) and (other.current == self.current)
         except AttributeError:

--- a/src/py/reactpy/tests/test_backend/test_all.py
+++ b/src/py/reactpy/tests/test_backend/test_all.py
@@ -107,7 +107,10 @@ async def test_use_scope(display: DisplayFixture):
     assert isinstance(scope.current, MutableMapping)
 
 
-@pytest.mark.skipIf(sys.platform == "darwin", reason="Tornado and Flask backends are currently buggy on MacOS.")
+@pytest.mark.skipIf(
+    sys.platform == "darwin",
+    reason="Tornado and Flask backends are currently buggy on MacOS.",
+)
 async def test_use_location(display: DisplayFixture):
     location = reactpy.Ref()
 

--- a/src/py/reactpy/tests/test_backend/test_all.py
+++ b/src/py/reactpy/tests/test_backend/test_all.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import MutableMapping
 
 import pytest
@@ -106,6 +107,7 @@ async def test_use_scope(display: DisplayFixture):
     assert isinstance(scope.current, MutableMapping)
 
 
+@pytest.mark.skipIf(sys.platform == "darwin", reason="Tornado and Flask backends are currently buggy on MacOS.")
 async def test_use_location(display: DisplayFixture):
     location = reactpy.Ref()
 

--- a/src/py/reactpy/tests/test_core/test_events.py
+++ b/src/py/reactpy/tests/test_core/test_events.py
@@ -193,7 +193,7 @@ async def test_can_stop_event_propagation(display: DisplayFixture):
             clicked.current = True
 
         def outer_click_is_not_triggered(event):
-            raise AssertionError()
+            raise AssertionError
 
         outer = reactpy.html.div(
             {


### PR DESCRIPTION
## Description

Hotfixes to ReactPy's CI just to get things going.

Realistically, we should rewrite everything to...
- Drop NPM in favor of `Bun`
- Drop `flake8`, `isort`, and `black` in favor of `hatch fmt`
- Get rid of the monorepo structure

But that will be a significantly higher time commitment, so I'll leave that for another day.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
