### PR TITLE
Fix hook deprecation warning

### DIFF
--- a/src/py/reactpy/reactpy/backend/hooks.py
+++ b/src/py/reactpy/reactpy/backend/hooks.py
@@ -11,7 +11,7 @@ from reactpy.core.hooks import ConnectionContext, use_context  # nocov
 def use_connection() -> Connection[Any]:  # nocov
     """Get the current :class:`~reactpy.backend.types.Connection`."""
     warn(
-        "The module reactpy.backend.hooks has been deprecated and will be deleted in the future. ",
+        "The module reactpy.backend.hooks has been deprecated and will be deleted in the future. "
         "Call reactpy.use_connection instead.",
         DeprecationWarning,
     )
@@ -26,7 +26,7 @@ def use_connection() -> Connection[Any]:  # nocov
 def use_scope() -> MutableMapping[str, Any]:  # nocov
     """Get the current :class:`~reactpy.backend.types.Connection`'s scope."""
     warn(
-        "The module reactpy.backend.hooks has been deprecated and will be deleted in the future. ",
+        "The module reactpy.backend.hooks has been deprecated and will be deleted in the future. "
         "Call reactpy.use_scope instead.",
         DeprecationWarning,
     )
@@ -37,7 +37,7 @@ def use_scope() -> MutableMapping[str, Any]:  # nocov
 def use_location() -> Location:  # nocov
     """Get the current :class:`~reactpy.backend.types.Connection`'s location."""
     warn(
-        "The module reactpy.backend.hooks has been deprecated and will be deleted in the future. ",
+        "The module reactpy.backend.hooks has been deprecated and will be deleted in the future. "
         "Call reactpy.use_location instead.",
         DeprecationWarning,
     )


### PR DESCRIPTION
## Description

A typo in the hook deprecation warning from #1210 was causing errors.

This removes the extra commas that were problematic.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
