### PR TITLE
Fix heroku publishing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,6 +17,8 @@ jobs:
               run: |
                   git fetch --prune --unshallow
                   git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+            - name: Install Heroku CLI
+              run: curl https://cli-assets.heroku.com/install.sh | sh
             - name: Login to Heroku Container Registry
               run: echo ${{ secrets.HEROKU_API_KEY }} | docker login -u ${{ secrets.HEROKU_EMAIL }} --password-stdin registry.heroku.com
             - name: Build Docker Image


### PR DESCRIPTION
## Description

Seems like Heroku publishing is broken for some reason, due to the following error: `heroku: command not found`

This PR attempts to add the heroku command to the deployment CI via standard Linux installation methods

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
