### PR TITLE
Create separate `use_async_effect` hook

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -21,6 +21,7 @@ Unreleased
 - :pull:`1113` - Added ``reactpy.jinja.Component`` that can be used alongside ``ReactPyMiddleware`` to embed several ReactPy components into your existing application.
 - :pull:`1113` - Added ``standard``, ``uvicorn``, ``jinja`` installation extras (for example ``pip install reactpy[standard]``).
 - :pull:`1113` - Added support for Python 3.12 and 3.13.
+- :pull:`1264` - Added ``reactpy.use_async_effect`` hook.
 
 **Changed**
 
@@ -46,6 +47,7 @@ Unreleased
 - :pull:`1113` - All backend related installation extras (such as ``pip install reactpy[starlette]``) have been removed.
 - :pull:`1113` - Removed deprecated function ``module_from_template``.
 - :pull:`1113` - Removed support for Python 3.9.
+- :pull:`1264` - Removed support for async functions within ``reactpy.use_effect`` hook. Use ``reactpy.use_async_effect`` instead.
 
 **Fixed**
 

--- a/docs/source/reference/_examples/simple_dashboard.py
+++ b/docs/source/reference/_examples/simple_dashboard.py
@@ -49,7 +49,7 @@ def RandomWalkGraph(mu, sigma):
     interval = use_interval(0.5)
     data, set_data = reactpy.hooks.use_state([{"x": 0, "y": 0}] * 50)
 
-    @reactpy.hooks.use_effect
+    @reactpy.hooks.use_async_effect
     async def animate():
         await interval
         last_data_point = data[-1]

--- a/docs/source/reference/_examples/snake_game.py
+++ b/docs/source/reference/_examples/snake_game.py
@@ -90,7 +90,7 @@ def GameLoop(grid_size, block_scale, set_game_state):
 
     interval = use_interval(0.5)
 
-    @reactpy.hooks.use_effect
+    @reactpy.hooks.use_async_effect
     async def animate():
         if new_game_state is not None:
             await asyncio.sleep(1)

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -500,9 +500,8 @@ async def test_use_async_effect_cleanup():
     @reactpy.component
     @component_hook.capture
     def ComponentWithAsyncEffect():
-        @reactpy.hooks.use_async_effect(
-            dependencies=None
-        )  # force this to run every time
+        # force this to run every time
+        @reactpy.hooks.use_async_effect(dependencies=None)
         async def effect():
             effect_ran.set()
             return cleanup_ran.set

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -481,7 +481,7 @@ async def test_use_async_effect():
 
     @reactpy.component
     def ComponentWithAsyncEffect():
-        @reactpy.hooks.use_effect
+        @reactpy.hooks.use_async_effect
         async def effect():
             effect_ran.set()
 
@@ -500,7 +500,9 @@ async def test_use_async_effect_cleanup():
     @reactpy.component
     @component_hook.capture
     def ComponentWithAsyncEffect():
-        @reactpy.hooks.use_effect(dependencies=None)  # force this to run every time
+        @reactpy.hooks.use_async_effect(
+            dependencies=None
+        )  # force this to run every time
         async def effect():
             effect_ran.set()
             return cleanup_ran.set
@@ -527,7 +529,8 @@ async def test_use_async_effect_cancel(caplog):
     @reactpy.component
     @component_hook.capture
     def ComponentWithLongWaitingEffect():
-        @reactpy.hooks.use_effect(dependencies=None)  # force this to run every time
+        # force this to run every time
+        @reactpy.hooks.use_async_effect(dependencies=None)
         async def effect():
             effect_ran.set()
             try:

--- a/tests/test_core/test_layout.py
+++ b/tests/test_core/test_layout.py
@@ -12,7 +12,7 @@ import reactpy
 from reactpy import html
 from reactpy.config import REACTPY_ASYNC_RENDERING, REACTPY_DEBUG
 from reactpy.core.component import component
-from reactpy.core.hooks import use_effect, use_state
+from reactpy.core.hooks import use_async_effect, use_effect, use_state
 from reactpy.core.layout import Layout
 from reactpy.testing import (
     HookCatcher,
@@ -1016,7 +1016,7 @@ async def test_element_keys_inside_components_do_not_reset_state_of_component():
     def Child(child_key):
         state, set_state = use_state(0)
 
-        @use_effect
+        @use_async_effect
         async def record_if_state_is_reset():
             if state:
                 return

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -17,7 +17,7 @@ async def test_script_re_run_on_content_change(display: DisplayFixture):
             set_count(count + 1)
 
         return html.div(
-            html.div({"id": "mount-count", "dataValue": 0}),
+            html.div({"id": "mount-count", "data-value": 0}),
             html.script(
                 f'document.getElementById("mount-count").setAttribute("data-value", {count});'
             ),
@@ -57,7 +57,7 @@ async def test_script_from_src(display: DisplayFixture):
             return html.div()
         else:
             return html.div(
-                html.div({"id": "run-count", "dataValue": 0}),
+                html.div({"id": "run-count", "data-value": 0}),
                 html.script(
                     {
                         "src": f"/reactpy/modules/{file_name_template.format(src_id=src_id)}"


### PR DESCRIPTION
## Description

ReactPy is made to mimick ReactJS as close to 1:1 as possible.

However, despite this we have support for async effects. Additionally, async effects bring their own technical challenges, especially related to effect cancellation.

This PR forces `use_effect` to only exist for synchronous functions, and creates a separate `use_async_effect` function. This allows `use_effect` to better align with the ReactJS equivalent, and subsequently allow `use_async_effect` to accept additional arguments that deviate from ReactJS. For example, in the future we may add a `timeout` value to `use_effect`.

Tangentially related issues: 
- https://github.com/reactive-python/reactpy/issues/956
- https://github.com/reactive-python/reactpy/issues/1136

Follow-up PR:
- https://github.com/reactive-python/reactpy/pull/1267

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
