### PR TITLE
Allow user defined routes in `ReactPy()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,6 @@ exclude_also = [
 ]
 
 [tool.ruff]
-target-version = "py39"
 line-length = 88
 lint.select = [
   "A",
@@ -328,13 +327,6 @@ lint.unfixable = [
 [tool.ruff.lint.isort]
 known-first-party = ["reactpy"]
 
-[tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
-
-[tool.flake8]
-select = ["RPY"]                                                  # only need to check with reactpy-flake8
-exclude = ["**/node_modules/*", ".eggs/*", ".tox/*", "**/venv/*"]
-
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "**/tests/**/*" = ["PLR2004", "S101", "TID252"]
@@ -350,7 +342,3 @@ exclude = ["**/node_modules/*", ".eggs/*", ".tox/*", "**/venv/*"]
   # Allow print
   "T201",
 ]
-
-[tool.black]
-target-version = ["py39"]
-line-length = 88

--- a/src/reactpy/asgi/standalone.py
+++ b/src/reactpy/asgi/standalone.py
@@ -90,20 +90,23 @@ class ReactPy(ReactPyMiddleware):
         self,
         path: str,
         type: Literal["http"] = "http",
-    ) -> Callable[[AsgiHttpApp | str], None]: ...
+    ) -> Callable[[AsgiHttpApp | str], AsgiApp]: ...
 
     @overload
     def route(
         self,
         path: str,
         type: Literal["websocket"],
-    ) -> Callable[[AsgiWebsocketApp | str], None]: ...
+    ) -> Callable[[AsgiWebsocketApp | str], AsgiApp]: ...
 
     def route(
         self,
         path: str,
         type: Literal["http", "websocket"] = "http",
-    ) -> Callable[[AsgiHttpApp | str], None] | Callable[[AsgiWebsocketApp | str], None]:
+    ) -> (
+        Callable[[AsgiHttpApp | str], AsgiApp]
+        | Callable[[AsgiWebsocketApp | str], AsgiApp]
+    ):
         """Interface that allows user to define their own HTTP/Websocket routes
         within the current ReactPy application.
 
@@ -114,7 +117,7 @@ class ReactPy(ReactPyMiddleware):
 
         def decorator(
             app: AsgiApp | str,
-        ) -> None:
+        ) -> AsgiApp:
             re_path = path
             if not re_path.startswith("^"):
                 re_path = f"^{re_path}"
@@ -126,6 +129,8 @@ class ReactPy(ReactPyMiddleware):
                 self.extra_http_routes[re_path] = cast(AsgiHttpApp, asgi_app)
             elif type == "websocket":
                 self.extra_ws_routes[re_path] = cast(AsgiWebsocketApp, asgi_app)
+
+            return asgi_app
 
         return decorator
 

--- a/src/reactpy/asgi/standalone.py
+++ b/src/reactpy/asgi/standalone.py
@@ -6,14 +6,28 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import formatdate
 from logging import getLogger
+from typing import Callable, Literal, cast, overload
 
 from asgiref import typing as asgi_types
 from typing_extensions import Unpack
 
 from reactpy import html
 from reactpy.asgi.middleware import ReactPyMiddleware
-from reactpy.asgi.utils import dict_to_byte_list, http_response, vdom_head_to_html
-from reactpy.types import ReactPyConfig, RootComponentConstructor, VdomDict
+from reactpy.asgi.utils import (
+    dict_to_byte_list,
+    http_response,
+    import_dotted_path,
+    vdom_head_to_html,
+)
+from reactpy.types import (
+    AsgiApp,
+    AsgiHttpApp,
+    AsgiLifespanApp,
+    AsgiWebsocketApp,
+    ReactPyConfig,
+    RootComponentConstructor,
+    VdomDict,
+)
 from reactpy.utils import render_mount_template
 
 _logger = getLogger(__name__)
@@ -34,7 +48,7 @@ class ReactPy(ReactPyMiddleware):
         """ReactPy's standalone ASGI application.
 
         Parameters:
-            root_component: The root component to render. This component is assumed to be a single page application.
+            root_component: The root component to render. This app is typically a single page application.
             http_headers: Additional headers to include in the HTTP response for the base HTML document.
             html_head: Additional head elements to include in the HTML response.
             html_lang: The language of the HTML document.
@@ -50,6 +64,84 @@ class ReactPy(ReactPyMiddleware):
     def match_dispatch_path(self, scope: asgi_types.WebSocketScope) -> bool:
         """Method override to remove `dotted_path` from the dispatcher URL."""
         return str(scope["path"]) == self.dispatcher_path
+
+    def match_extra_paths(self, scope: asgi_types.Scope) -> AsgiApp | None:
+        """Method override to match user-provided HTTP/Websocket routes."""
+        if scope["type"] == "lifespan":
+            return self.extra_lifespan_app
+
+        if scope["type"] == "http":
+            routing_dictionary = self.extra_http_routes.items()
+
+        if scope["type"] == "websocket":
+            routing_dictionary = self.extra_ws_routes.items()  # type: ignore
+
+        return next(
+            (
+                app
+                for route, app in routing_dictionary
+                if re.match(route, scope["path"])
+            ),
+            None,
+        )
+
+    @overload
+    def route(
+        self,
+        path: str,
+        type: Literal["http"] = "http",
+    ) -> Callable[[AsgiHttpApp | str], None]: ...
+
+    @overload
+    def route(
+        self,
+        path: str,
+        type: Literal["websocket"],
+    ) -> Callable[[AsgiWebsocketApp | str], None]: ...
+
+    def route(
+        self,
+        path: str,
+        type: Literal["http", "websocket"] = "http",
+    ) -> Callable[[AsgiHttpApp | str], None] | Callable[[AsgiWebsocketApp | str], None]:
+        """Interface that allows user to define their own HTTP/Websocket routes
+        within the current ReactPy application.
+
+        Parameters:
+            path: The URL route to match, using regex format.
+            type: The protocol to route for. Can be 'http' or 'websocket'.
+        """
+
+        def decorator(
+            app: AsgiApp | str,
+        ) -> None:
+            re_path = path
+            if not re_path.startswith("^"):
+                re_path = f"^{re_path}"
+            if not re_path.endswith("$"):
+                re_path = f"{re_path}$"
+
+            asgi_app: AsgiApp = import_dotted_path(app) if isinstance(app, str) else app
+            if type == "http":
+                self.extra_http_routes[re_path] = cast(AsgiHttpApp, asgi_app)
+            elif type == "websocket":
+                self.extra_ws_routes[re_path] = cast(AsgiWebsocketApp, asgi_app)
+
+        return decorator
+
+    def lifespan(self, app: AsgiLifespanApp | str) -> None:
+        """Interface that allows user to define their own lifespan app
+        within the current ReactPy application.
+
+        Parameters:
+            app: The ASGI application to route to.
+        """
+        if self.extra_lifespan_app:
+            raise ValueError("Only one lifespan app can be defined.")
+
+        self.extra_lifespan_app = (
+            import_dotted_path(app) if isinstance(app, str) else app
+        )
 
 
 @dataclass

--- a/src/reactpy/testing/backend.py
+++ b/src/reactpy/testing/backend.py
@@ -140,7 +140,7 @@ class BackendFixture:
             raise LogAssertionError(msg) from logged_errors[0]
 
         await asyncio.wait_for(
-            self.webserver.shutdown(), timeout=60 if GITHUB_ACTIONS else 5
+            self.webserver.shutdown(), timeout=90 if GITHUB_ACTIONS else 5
         )
 
     async def restart(self) -> None:

--- a/src/reactpy/types.py
+++ b/src/reactpy/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections import namedtuple
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
@@ -15,6 +15,7 @@ from typing import (
     NamedTuple,
     Protocol,
     TypeVar,
+    Union,
     overload,
     runtime_checkable,
 )
@@ -296,3 +297,73 @@ class ReactPyConfig(TypedDict, total=False):
     async_rendering: bool
     debug: bool
     tests_default_timeout: int
+
+
+AsgiHttpReceive = Callable[
+    [],
+    Awaitable[asgi_types.HTTPRequestEvent | asgi_types.HTTPDisconnectEvent],
+]
+
+AsgiHttpSend = Callable[
+    [
+        asgi_types.HTTPResponseStartEvent
+        | asgi_types.HTTPResponseBodyEvent
+        | asgi_types.HTTPResponseTrailersEvent
+        | asgi_types.HTTPServerPushEvent
+        | asgi_types.HTTPDisconnectEvent
+    ],
+    Awaitable[None],
+]
+
+AsgiWebsocketReceive = Callable[
+    [],
+    Awaitable[
+        asgi_types.WebSocketConnectEvent
+        | asgi_types.WebSocketDisconnectEvent
+        | asgi_types.WebSocketReceiveEvent
+    ],
+]
+
+AsgiWebsocketSend = Callable[
+    [
+        asgi_types.WebSocketAcceptEvent
+        | asgi_types.WebSocketSendEvent
+        | asgi_types.WebSocketResponseStartEvent
+        | asgi_types.WebSocketResponseBodyEvent
+        | asgi_types.WebSocketCloseEvent
+    ],
+    Awaitable[None],
+]
+
+AsgiLifespanReceive = Callable[
+    [],
+    Awaitable[asgi_types.LifespanStartupEvent | asgi_types.LifespanShutdownEvent],
+]
+
+AsgiLifespanSend = Callable[
+    [
+        asgi_types.LifespanStartupCompleteEvent
+        | asgi_types.LifespanStartupFailedEvent
+        | asgi_types.LifespanShutdownCompleteEvent
+        | asgi_types.LifespanShutdownFailedEvent
+    ],
+    Awaitable[None],
+]
+
+AsgiHttpApp = Callable[
+    [asgi_types.HTTPScope, AsgiHttpReceive, AsgiHttpSend],
+    Awaitable[None],
+]
+
+AsgiWebsocketApp = Callable[
+    [asgi_types.WebSocketScope, AsgiWebsocketReceive, AsgiWebsocketSend],
+    Awaitable[None],
+]
+
+AsgiLifespanApp = Callable[
+    [asgi_types.LifespanScope, AsgiLifespanReceive, AsgiLifespanSend],
+    Awaitable[None],
+]
+
+
+AsgiApp = Union[AsgiHttpApp, AsgiWebsocketApp, AsgiLifespanApp]


### PR DESCRIPTION
## Description

Since ReactPy client-side support is coming to this repo soon, it will necessitate allowing users to create REST endpoints within their ReactPy server.

This PR allows users to register arbitrary ASGI apps within ReactPy's standalone mode.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
