### PR TITLE
Run test webserver within main async loop

### DIFF
--- a/src/reactpy/testing/backend.py
+++ b/src/reactpy/testing/backend.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import AsyncExitStack
-from threading import Thread
 from types import TracebackType
 from typing import Any, Callable
 from urllib.parse import urlencode, urlunparse
@@ -16,7 +15,6 @@ from reactpy.asgi.standalone import ReactPy
 from reactpy.config import REACTPY_TESTS_DEFAULT_TIMEOUT
 from reactpy.core.component import component
 from reactpy.core.hooks import use_callback, use_effect, use_state
-from reactpy.testing.common import GITHUB_ACTIONS
 from reactpy.testing.logs import (
     LogAssertionError,
     capture_reactpy_logs,

--- a/tests/test_asgi/test_standalone.py
+++ b/tests/test_asgi/test_standalone.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import MutableMapping
 
 import pytest
@@ -155,8 +156,8 @@ async def test_head_request(page):
         async with DisplayFixture(backend=server, driver=page) as new_display:
             await new_display.show(sample)
             url = f"http://{server.host}:{server.port}"
-            response = request(
-                "HEAD", url, timeout=REACTPY_TESTS_DEFAULT_TIMEOUT.current
+            response = await asyncio.to_thread(
+                request, "HEAD", url, timeout=REACTPY_TESTS_DEFAULT_TIMEOUT.current
             )
             assert response.status_code == 200
             assert response.headers["content-type"] == "text/html; charset=utf-8"


### PR DESCRIPTION
## Description

The test webserver struggles to startup/shutdown on GitHub Actions, seemingly due to weirdness with Python threads.

Unfortunately, subprocesses won't work due to pickling issues. As a result, the only obvious alternative is running the webserver directly within the main thread's asyncio loop.

This seems to work for the purpose of running tests.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
