### PR TITLE
Better async effect shutdown behavior

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -22,6 +22,7 @@ Unreleased
 - :pull:`1113` - Added ``standard``, ``uvicorn``, ``jinja`` installation extras (for example ``pip install reactpy[standard]``).
 - :pull:`1113` - Added support for Python 3.12 and 3.13.
 - :pull:`1264` - Added ``reactpy.use_async_effect`` hook.
+- :pull:`1267` - Added ``shutdown_timeout`` parameter to the ``reactpy.use_async_effect`` hook.
 
 **Changed**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,15 +93,13 @@ testing = ["playwright"]
 [tool.hatch.envs.hatch-test]
 extra-dependencies = [
   "pytest-sugar",
-  "pytest-asyncio>=0.23",
-  "pytest-timeout",
-  "coverage[toml]>=6.5",
+  "pytest-asyncio",
   "responses",
   "playwright",
   "jsonpointer",
   "uvicorn[standard]",
   "jinja2-simple-tags",
-  "jinja2 >=3",
+  "jinja2",
   "starlette",
 ]
 

--- a/src/reactpy/__init__.py
+++ b/src/reactpy/__init__.py
@@ -7,6 +7,7 @@ from reactpy.core.component import component
 from reactpy.core.events import event
 from reactpy.core.hooks import (
     create_context,
+    use_async_effect,
     use_callback,
     use_connection,
     use_context,
@@ -41,6 +42,7 @@ __all__ = [
     "html_to_vdom",
     "logging",
     "types",
+    "use_async_effect",
     "use_callback",
     "use_connection",
     "use_context",

--- a/src/reactpy/__init__.py
+++ b/src/reactpy/__init__.py
@@ -25,7 +25,7 @@ from reactpy.core.vdom import vdom
 from reactpy.utils import Ref, html_to_vdom, vdom_to_html
 
 __author__ = "The Reactive Python Team"
-__version__ = "2.0.0a0"
+__version__ = "2.0.0a1"
 
 __all__ = [
     "Layout",

--- a/src/reactpy/core/hooks.py
+++ b/src/reactpy/core/hooks.py
@@ -173,6 +173,7 @@ def use_effect(
 def use_async_effect(
     function: None = None,
     dependencies: Sequence[Any] | ellipsis | None = ...,
+    shutdown_timeout: float = 0.1,
 ) -> Callable[[_EffectApplyFunc], None]: ...
 
 
@@ -180,6 +181,7 @@ def use_async_effect(
 def use_async_effect(
     function: _AsyncEffectFunc,
     dependencies: Sequence[Any] | ellipsis | None = ...,
+    shutdown_timeout: float = 0.1,
 ) -> None: ...
 
 
@@ -227,8 +229,8 @@ def use_async_effect(
             # Wait until we get the signal to stop this effect
             await stop.wait()
 
-            # If renders are queued back-to-back, then this effect function might have
-            # not completed. So, we give the task a small amount of time to finish.
+            # If renders are queued back-to-back, the effect might not have
+            # completed. So, we give the task a small amount of time to finish.
             # If it manages to finish, we can obtain a clean-up function.
             results, _ = await asyncio.wait([task], timeout=shutdown_timeout)
             if results:

--- a/src/reactpy/core/hooks.py
+++ b/src/reactpy/core/hooks.py
@@ -30,6 +30,7 @@ if not TYPE_CHECKING:
 
 
 __all__ = [
+    "use_async_effect",
     "use_callback",
     "use_effect",
     "use_memo",

--- a/src/reactpy/core/hooks.py
+++ b/src/reactpy/core/hooks.py
@@ -120,7 +120,12 @@ def use_effect(
     function: _SyncEffectFunc | None = None,
     dependencies: Sequence[Any] | ellipsis | None = ...,
 ) -> Callable[[_SyncEffectFunc], None] | None:
-    """See the full :ref:`Use Effect` docs for details
+    """
+    A hook that manages an synchronous side effect in a React-like component.
+
+    This hook allows you to run a synchronous function as a side effect and
+    ensures that the effect is properly cleaned up when the component is
+    re-rendered or unmounted.
 
     Parameters:
         function:


### PR DESCRIPTION
## Description

Asynchronous code is fundamentally tricky to handle, given issues with race conditions and task cancellation. This is significant to us since we currently support asynchronous effects within `use_async_effect`.

This PR attempts to alleviate some of those concerns by giving asynchronous effect functions a small amount of time (configurable) to finish executing before being forcibly shutdown.

Additionally, this PR refactors `use_effect` code to be human-readable.

- fix #956

Predecessor PR:

- https://github.com/reactive-python/reactpy/pull/1264

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
