### PR TITLE
Improved default transforms for `vdom_to_html`

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -25,7 +25,6 @@ Unreleased
 - :pull:`1113` - Added support for Python 3.12 and 3.13.
 - :pull:`1264` - Added ``reactpy.use_async_effect`` hook.
 - :pull:`1267` - Added ``shutdown_timeout`` parameter to the ``reactpy.use_async_effect`` hook.
-- :pull:`1278` - ``reactpy.utils.html_to_vdom`` has been upgraded to handle more complex scenarios without causing ReactJS rendering errors.
 
 **Changed**
 
@@ -39,7 +38,8 @@ Unreleased
 - :pull:`1113` - Renamed ``reactpy.config.REACTPY_DEBUG_MODE`` to ``reactpy.config.REACTPY_DEBUG``.
 - :pull:`1113` - ``@reactpy/client`` now exports ``React`` and ``ReactDOM``.
 - :pull:`1263` - ReactPy no longer auto-converts ``snake_case`` props to ``camelCase``. It is now the responsibility of the user to ensure that props are in the correct format.
-- :pull:`1278` - ``reactpy.utils.vdom_to_html`` will now retain the user's original casing for element ``data-*`` and ``aria-*`` attributes.
+- :pull:`1278` - ``reactpy.utils.reactpy_to_string`` will now retain the user's original casing for ``data-*`` and ``aria-*`` attributes.
+- :pull:`1278` - ``reactpy.utils.string_to_reactpy`` has been upgraded to handle more complex scenarios without causing ReactJS rendering errors.
 
 **Removed**
 
@@ -50,6 +50,8 @@ Unreleased
 - :pull:`1113` - Removed ``reactpy.run``. See the documentation for the new method to run ReactPy applications.
 - :pull:`1113` - Removed ``reactpy.backend.*``. See the documentation for the new method to run ReactPy applications.
 - :pull:`1113` - Removed ``reactpy.core.types`` module. Use ``reactpy.types`` instead.
+- :pull:`1278` - Removed ``reactpy.utils.html_to_vdom``. Use ``reactpy.utils.string_to_reactpy`` instead.
+- :pull:`1278` - Removed ``reactpy.utils.vdom_to_html``. Use ``reactpy.utils.reactpy_to_string`` instead.
 - :pull:`1113` - All backend related installation extras (such as ``pip install reactpy[starlette]``) have been removed.
 - :pull:`1113` - Removed deprecated function ``module_from_template``.
 - :pull:`1113` - Removed support for Python 3.9.

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -25,6 +25,7 @@ Unreleased
 - :pull:`1113` - Added support for Python 3.12 and 3.13.
 - :pull:`1264` - Added ``reactpy.use_async_effect`` hook.
 - :pull:`1267` - Added ``shutdown_timeout`` parameter to the ``reactpy.use_async_effect`` hook.
+- :pull:`1278` - ``reactpy.utils.html_to_vdom`` has been upgraded to handle more complex scenarios without causing ReactJS rendering errors.
 
 **Changed**
 
@@ -38,6 +39,7 @@ Unreleased
 - :pull:`1113` - Renamed ``reactpy.config.REACTPY_DEBUG_MODE`` to ``reactpy.config.REACTPY_DEBUG``.
 - :pull:`1113` - ``@reactpy/client`` now exports ``React`` and ``ReactDOM``.
 - :pull:`1263` - ReactPy no longer auto-converts ``snake_case`` props to ``camelCase``. It is now the responsibility of the user to ensure that props are in the correct format.
+- :pull:`1278` - ``reactpy.utils.vdom_to_html`` will now retain the user's original casing for element ``data-*`` and ``aria-*`` attributes.
 
 **Removed**
 

--- a/src/reactpy/__init__.py
+++ b/src/reactpy/__init__.py
@@ -21,7 +21,7 @@ from reactpy.core.hooks import (
 from reactpy.core.layout import Layout
 from reactpy.core.vdom import vdom
 from reactpy.pyscript.components import pyscript_component
-from reactpy.utils import Ref, html_to_vdom, vdom_to_html
+from reactpy.utils import Ref, reactpy_to_string, string_to_reactpy
 
 __author__ = "The Reactive Python Team"
 __version__ = "2.0.0a1"
@@ -35,9 +35,10 @@ __all__ = [
     "event",
     "hooks",
     "html",
-    "html_to_vdom",
     "logging",
     "pyscript_component",
+    "reactpy_to_string",
+    "string_to_reactpy",
     "types",
     "use_async_effect",
     "use_callback",
@@ -52,7 +53,6 @@ __all__ = [
     "use_scope",
     "use_state",
     "vdom",
-    "vdom_to_html",
     "web",
     "widgets",
 ]

--- a/src/reactpy/core/_life_cycle_hook.py
+++ b/src/reactpy/core/_life_cycle_hook.py
@@ -22,7 +22,7 @@ class EffectFunc(Protocol):
 logger = logging.getLogger(__name__)
 
 
-class _HookStack(Singleton):  # pragma: no cover
+class _HookStack(Singleton):  # nocov
     """A singleton object which manages the current component tree's hooks.
     Life cycle hooks can be stored in a thread local or context variable depending
     on the platform."""

--- a/src/reactpy/core/_thread_local.py
+++ b/src/reactpy/core/_thread_local.py
@@ -5,7 +5,7 @@ from weakref import WeakKeyDictionary
 _StateType = TypeVar("_StateType")
 
 
-class ThreadLocal(Generic[_StateType]):  # pragma: no cover
+class ThreadLocal(Generic[_StateType]):  # nocov
     """Utility for managing per-thread state information. This is only used in
     environments where ContextVars are not available, such as the `pyodide`
     executor."""

--- a/src/reactpy/core/hooks.py
+++ b/src/reactpy/core/hooks.py
@@ -613,7 +613,7 @@ def strictly_equal(x: Any, y: Any) -> bool:
             return x == y  # type: ignore
 
     # Fallback to identity check
-    return x is y  # pragma: no cover
+    return x is y  # nocov
 
 
 def run_effect_cleanup(cleanup_func: Ref[_EffectCleanFunc | None]) -> None:

--- a/src/reactpy/executors/asgi/middleware.py
+++ b/src/reactpy/executors/asgi/middleware.py
@@ -166,7 +166,7 @@ class ComponentDispatchApp:
                     msg: dict[str, str] = orjson.loads(event["text"])
                     if msg.get("type") == "layout-event":
                         await ws.rendering_queue.put(msg)
-                    else:  # pragma: no cover
+                    else:  # nocov
                         await asyncio.to_thread(
                             _logger.warning, f"Unknown message type: {msg.get('type')}"
                         )
@@ -205,7 +205,7 @@ class ReactPyWebsocket(ResponseWebSocket):
             # Determine component to serve by analyzing the URL and/or class parameters.
             if self.parent.multiple_root_components:
                 url_match = re.match(self.parent.dispatcher_pattern, self.scope["path"])
-                if not url_match:  # pragma: no cover
+                if not url_match:  # nocov
                     raise RuntimeError("Could not find component in URL path.")
                 dotted_path = url_match["dotted_path"]
                 if dotted_path not in self.parent.root_components:
@@ -215,7 +215,7 @@ class ReactPyWebsocket(ResponseWebSocket):
                 component = self.parent.root_components[dotted_path]
             elif self.parent.root_component:
                 component = self.parent.root_component
-            else:  # pragma: no cover
+            else:  # nocov
                 raise RuntimeError("No root component provided.")
 
             # Create a connection object by analyzing the websocket's query string.

--- a/src/reactpy/executors/asgi/pyscript.py
+++ b/src/reactpy/executors/asgi/pyscript.py
@@ -79,9 +79,7 @@ class ReactPyPyscript(ReactPy):
         self.html_head = html_head or html.head()
         self.html_lang = html_lang
 
-    def match_dispatch_path(
-        self, scope: AsgiWebsocketScope
-    ) -> bool:  # pragma: no cover
+    def match_dispatch_path(self, scope: AsgiWebsocketScope) -> bool:  # nocov
         """We do not use a WebSocket dispatcher for Client-Side Rendering (CSR)."""
         return False
 

--- a/src/reactpy/executors/asgi/standalone.py
+++ b/src/reactpy/executors/asgi/standalone.py
@@ -182,7 +182,7 @@ class ReactPyApp:
     async def __call__(
         self, scope: AsgiScope, receive: AsgiReceive, send: AsgiSend
     ) -> None:
-        if scope["type"] != "http":  # pragma: no cover
+        if scope["type"] != "http":  # nocov
             if scope["type"] != "lifespan":
                 msg = (
                     "ReactPy app received unsupported request of type '%s' at path '%s'",

--- a/src/reactpy/executors/asgi/standalone.py
+++ b/src/reactpy/executors/asgi/standalone.py
@@ -31,7 +31,7 @@ from reactpy.types import (
     RootComponentConstructor,
     VdomDict,
 )
-from reactpy.utils import html_to_vdom, import_dotted_path
+from reactpy.utils import import_dotted_path, string_to_reactpy
 
 _logger = getLogger(__name__)
 
@@ -74,7 +74,7 @@ class ReactPy(ReactPyMiddleware):
             extra_py = pyscript_options.get("extra_py", [])
             extra_js = pyscript_options.get("extra_js", {})
             config = pyscript_options.get("config", {})
-            pyscript_head_vdom = html_to_vdom(
+            pyscript_head_vdom = string_to_reactpy(
                 pyscript_setup_html(extra_py, extra_js, config)
             )
             pyscript_head_vdom["tagName"] = ""

--- a/src/reactpy/executors/utils.py
+++ b/src/reactpy/executors/utils.py
@@ -13,7 +13,7 @@ from reactpy.config import (
     REACTPY_RECONNECT_MAX_RETRIES,
 )
 from reactpy.types import ReactPyConfig, VdomDict
-from reactpy.utils import import_dotted_path, vdom_to_html
+from reactpy.utils import import_dotted_path, reactpy_to_string
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def check_path(url_path: str) -> str:  # nocov
 
 def vdom_head_to_html(head: VdomDict) -> str:
     if isinstance(head, dict) and head.get("tagName") == "head":
-        return vdom_to_html(head)
+        return reactpy_to_string(head)
 
     raise ValueError(
         "Invalid head element! Element must be either `html.head` or a string."

--- a/src/reactpy/executors/utils.py
+++ b/src/reactpy/executors/utils.py
@@ -25,7 +25,7 @@ def import_components(dotted_paths: Iterable[str]) -> dict[str, Any]:
     }
 
 
-def check_path(url_path: str) -> str:  # pragma: no cover
+def check_path(url_path: str) -> str:  # nocov
     """Check that a path is valid URL path."""
     if not url_path:
         return "URL path must not be empty."

--- a/src/reactpy/pyscript/components.py
+++ b/src/reactpy/pyscript/components.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from reactpy import component, hooks
 from reactpy.pyscript.utils import pyscript_component_html
 from reactpy.types import ComponentType, Key
-from reactpy.utils import html_to_vdom
+from reactpy.utils import string_to_reactpy
 
 if TYPE_CHECKING:
     from reactpy.types import VdomDict
@@ -22,7 +22,7 @@ def _pyscript_component(
         raise ValueError("At least one file path must be provided.")
 
     rendered, set_rendered = hooks.use_state(False)
-    initial = html_to_vdom(initial) if isinstance(initial, str) else initial
+    initial = string_to_reactpy(initial) if isinstance(initial, str) else initial
 
     if not rendered:
         # FIXME: This is needed to properly re-render PyScript during a WebSocket
@@ -30,7 +30,7 @@ def _pyscript_component(
         set_rendered(True)
         return None
 
-    component_vdom = html_to_vdom(
+    component_vdom = string_to_reactpy(
         pyscript_component_html(tuple(str(fp) for fp in file_paths), initial, root)
     )
     component_vdom["tagName"] = ""

--- a/src/reactpy/pyscript/utils.py
+++ b/src/reactpy/pyscript/utils.py
@@ -144,7 +144,7 @@ def extend_pyscript_config(
     return orjson.dumps(pyscript_config).decode("utf-8")
 
 
-def reactpy_version_string() -> str:  # pragma: no cover
+def reactpy_version_string() -> str:  # nocov
     from reactpy.testing.common import GITHUB_ACTIONS
 
     local_version = reactpy.__version__

--- a/src/reactpy/pyscript/utils.py
+++ b/src/reactpy/pyscript/utils.py
@@ -18,7 +18,7 @@ import jsonpointer
 import reactpy
 from reactpy.config import REACTPY_DEBUG, REACTPY_PATH_PREFIX, REACTPY_WEB_MODULES_DIR
 from reactpy.types import VdomDict
-from reactpy.utils import vdom_to_html
+from reactpy.utils import reactpy_to_string
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -77,7 +77,7 @@ def pyscript_component_html(
     file_paths: Sequence[str], initial: str | VdomDict, root: str
 ) -> str:
     """Renders a PyScript component with the user's code."""
-    _initial = initial if isinstance(initial, str) else vdom_to_html(initial)
+    _initial = initial if isinstance(initial, str) else reactpy_to_string(initial)
     uuid = uuid4().hex
     executor_code = pyscript_executor_html(file_paths=file_paths, uuid=uuid, root=root)
 

--- a/src/reactpy/templatetags/jinja.py
+++ b/src/reactpy/templatetags/jinja.py
@@ -22,7 +22,7 @@ class Jinja(StandaloneTag):  # type: ignore
             return pyscript_setup(*args, **kwargs)
 
         # This should never happen, but we validate it for safety.
-        raise ValueError(f"Unknown tag: {self.tag_name}")  # pragma: no cover
+        raise ValueError(f"Unknown tag: {self.tag_name}")  # nocov
 
 
 def component(dotted_path: str, **kwargs: str) -> str:

--- a/src/reactpy/testing/common.py
+++ b/src/reactpy/testing/common.py
@@ -16,6 +16,7 @@ from typing_extensions import ParamSpec
 from reactpy.config import REACTPY_TESTS_DEFAULT_TIMEOUT, REACTPY_WEB_MODULES_DIR
 from reactpy.core._life_cycle_hook import HOOK_STACK, LifeCycleHook
 from reactpy.core.events import EventHandler, to_event_handler_function
+from reactpy.utils import str_to_bool
 
 
 def clear_reactpy_web_modules_dir() -> None:
@@ -29,14 +30,7 @@ _R = TypeVar("_R")
 
 
 _DEFAULT_POLL_DELAY = 0.1
-GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS", "False") in {
-    "y",
-    "yes",
-    "t",
-    "true",
-    "on",
-    "1",
-}
+GITHUB_ACTIONS = str_to_bool(os.getenv("GITHUB_ACTIONS", ""))
 
 
 class poll(Generic[_R]):  # noqa: N801

--- a/src/reactpy/testing/display.py
+++ b/src/reactpy/testing/display.py
@@ -58,7 +58,7 @@ class DisplayFixture:
 
         self.page.set_default_timeout(REACTPY_TESTS_DEFAULT_TIMEOUT.current * 1000)
 
-        if not hasattr(self, "backend"):  # pragma: no cover
+        if not hasattr(self, "backend"):  # nocov
             self.backend = BackendFixture()
             await es.enter_async_context(self.backend)
 

--- a/src/reactpy/testing/utils.py
+++ b/src/reactpy/testing/utils.py
@@ -7,7 +7,7 @@ from contextlib import closing
 
 def find_available_port(
     host: str, port_min: int = 8000, port_max: int = 9000
-) -> int:  # pragma: no cover
+) -> int:  # nocov
     """Get a port that's available for the given host and port range"""
     for port in range(port_min, port_max):
         with closing(socket.socket()) as sock:

--- a/src/reactpy/transforms.py
+++ b/src/reactpy/transforms.py
@@ -7,7 +7,7 @@ from reactpy.types import VdomDict
 
 
 class RequiredTransforms:
-    """Performs any necessary transformations related to `html_to_vdom` to automatically prevent
+    """Performs any necessary transformations related to `string_to_reactpy` to automatically prevent
     issues with React's rendering engine.
     """
 
@@ -83,7 +83,7 @@ class RequiredTransforms:
     def input_element_value_prop_to_defaultValue(vdom: VdomDict) -> None:
         """ReactJS will complain that inputs are uncontrolled if defining the `value` prop,
         so we use `defaultValue` instead. This has an added benefit of not deleting/overriding
-        any user input when a `html_to_vdom` re-renders fields that do not retain their `value`,
+        any user input when a `string_to_reactpy` re-renders fields that do not retain their `value`,
         such as password fields."""
         if vdom["tagName"] != "input":
             return
@@ -106,7 +106,7 @@ class RequiredTransforms:
 
         # Infer 'key' from 'attributes.id'
         if key is None:
-        key = attributes.get("id")
+            key = attributes.get("id")
 
         # Infer 'key' from 'attributes.name'
         if key is None and vdom["tagName"] in {"input", "select", "textarea"}:

--- a/src/reactpy/transforms.py
+++ b/src/reactpy/transforms.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+from typing import Any
+
+from reactpy.core.events import EventHandler, to_event_handler_function
+from reactpy.types import VdomDict
+
+
+class RequiredTransforms:
+    """Performs any necessary transformations related to `html_to_vdom` to automatically prevent
+    issues with React's rendering engine.
+    """
+
+    def __init__(self, vdom: VdomDict, intercept_links: bool = True) -> None:
+        self._intercept_links = intercept_links
+
+        # Run every transform in this class.
+        for name in dir(self):
+            # Any method that doesn't start with an underscore is assumed to be a transform.
+            if not name.startswith("_"):
+                getattr(self, name)(vdom)
+
+    def normalize_style_attributes(self, vdom: VdomDict) -> None:
+        """Convert style attribute from str -> dict with camelCase keys"""
+        if (
+            "attributes" in vdom
+            and "style" in vdom["attributes"]
+            and isinstance(vdom["attributes"]["style"], str)
+        ):
+            vdom["attributes"]["style"] = {
+                self._kebab_to_camel_case(key.strip()): value.strip()
+                for key, value in (
+                    part.split(":", 1)
+                    for part in vdom["attributes"]["style"].split(";")
+                    if ":" in part
+                )
+            }
+
+    @staticmethod
+    def html_props_to_reactjs(vdom: VdomDict) -> None:
+        """Convert HTML prop names to their ReactJS equivalents."""
+        if "attributes" in vdom:
+            vdom["attributes"] = {
+                REACT_PROP_SUBSTITUTIONS.get(k, k): v
+                for k, v in vdom["attributes"].items()
+            }
+
+    @staticmethod
+    def textarea_children_to_prop(vdom: VdomDict) -> None:
+        """Transformation that converts the text content of a <textarea> to a ReactJS prop."""
+        if vdom["tagName"] == "textarea" and "children" in vdom and vdom["children"]:
+            text_content = vdom.pop("children")
+            text_content = "".join(
+                [child for child in text_content if isinstance(child, str)]
+            )
+
+            vdom.setdefault("attributes", {})
+            if "attributes" in vdom:
+                default_value = vdom["attributes"].pop("defaultValue", "")
+                vdom["attributes"]["defaultValue"] = text_content or default_value
+
+    def select_element_to_reactjs(self, vdom: VdomDict) -> None:
+        """Performs several transformations on the <select> element to make it ReactJS-compatible.
+
+        1. Convert the `selected` attribute on <option> is replaced with the ReactJS equivalent.
+            Namely, ReactJS uses props on the parent <select> element to indicate which <option> is selected.
+        2. Sets the `value` prop on each <option> element so that ReactJS knows the identity of each element."""
+        if vdom["tagName"] != "select" or "children" not in vdom:
+            return
+
+        vdom.setdefault("attributes", {})
+        if "attributes" in vdom:
+            multiple_choice = vdom["attributes"].get("multiple") is not None
+            selected_options = self._parse_options(vdom)
+            if multiple_choice:
+                vdom["attributes"]["multiple"] = True
+            if selected_options and not multiple_choice:
+                vdom["attributes"]["defaultValue"] = selected_options[0]
+            if selected_options and multiple_choice:
+                vdom["attributes"]["defaultValue"] = selected_options
+
+    @staticmethod
+    def input_element_value_prop_to_defaultValue(vdom: VdomDict) -> None:
+        """ReactJS will complain that inputs are uncontrolled if defining the `value` prop,
+        so we use `defaultValue` instead. This has an added benefit of not deleting/overriding
+        any user input when a `html_to_vdom` re-renders fields that do not retain their `value`,
+        such as password fields."""
+        if vdom["tagName"] != "input":
+            return
+
+        vdom.setdefault("attributes", {})
+        if "attributes" in vdom:
+            value = vdom["attributes"].pop("value", None)
+            if value is not None:
+                vdom["attributes"]["defaultValue"] = value
+
+    @staticmethod
+    def infer_key_from_attributes(vdom: VdomDict) -> None:
+        """Infer the ReactJS `key` by looking at any attributes that should be unique."""
+        attributes = vdom.get("attributes", {})
+
+        # Infer 'key' from 'id'
+        key = attributes.get("id")
+
+        # Fallback: Infer 'key' from 'name'
+        if not key and vdom["tagName"] in {"input", "select", "textarea"}:
+            key = attributes.get("name")
+
+        if key:
+            vdom["key"] = key
+
+    def intercept_link_clicks(self, vdom: VdomDict) -> None:
+        """Intercepts anchor link clicks and prevents the default behavior.
+        This allows ReactPy-Router to handle the navigation instead of the browser."""
+        if vdom["tagName"] != "a" or not self._intercept_links:
+            return
+
+        vdom.setdefault("eventHandlers", {})
+        if "eventHandlers" in vdom and isinstance(vdom["eventHandlers"], dict):
+            vdom["eventHandlers"]["onClick"] = EventHandler(
+                to_event_handler_function(lambda *_args, **_kwargs: None),
+                prevent_default=True,
+            )
+
+    def _parse_options(self, vdom_or_any: Any) -> list[str]:
+        """Parses a tree of elements to find all <option> elements with the 'selected' prop.
+        1. Sets the `value` prop on each <option> element so that ReactJS knows the identity of each element.
+        2. The 'selected' prop is removed, and this function returns a list of selected elements."""
+
+        # Since we recursively iterate through children, return early if the current node is not a dict.
+        selected_options = []
+        if not isinstance(vdom_or_any, dict):
+            return selected_options
+
+        vdom = vdom_or_any
+        if vdom["tagName"] == "option" and "attributes" in vdom:
+            value = vdom["attributes"].setdefault("value", vdom["children"][0])
+
+            if "selected" in vdom["attributes"]:
+                vdom["attributes"].pop("selected")
+                selected_options.append(value)
+
+        for child in vdom.get("children", []):
+            selected_options.extend(self._parse_options(child))
+
+        return selected_options
+
+    @staticmethod
+    def _kebab_to_camel_case(kebab_case: str) -> str:
+        """Convert kebab-case to camelCase."""
+        return "".join(
+            part.capitalize() if i else part
+            for i, part in enumerate(kebab_case.split("-"))
+        )
+
+
+KNOWN_REACT_PROPS = {
+    "onLoadStart",
+    "onTouchStart",
+    "onProgressCapture",
+    "contentEditable",
+    "dir",
+    "onClick",
+    "onTimeUpdateCapture",
+    "onPointerCancelCapture",
+    "charset",
+    "formEnctype",
+    "accessKey",
+    "required",
+    "onError",
+    "capture",
+    "formAction",
+    "onEmptiedCapture",
+    "hrefLang",
+    "form",
+    "onKeyDownCapture",
+    "onMouseUpCapture",
+    "onBeforeInput",
+    "onCutCapture",
+    "onDurationChange",
+    "onCanPlayCapture",
+    "onGotPointerCapture",
+    "onSuspend",
+    "inputMode",
+    "onPointerCancel",
+    "onSuspendCapture",
+    "onKeyDown",
+    "onTimeUpdate",
+    "maxLength",
+    "onDropCapture",
+    "onCompositionUpdateCapture",
+    "nonce",
+    "onKeyUp",
+    "title",
+    "onSeekingCapture",
+    "onStalledCapture",
+    "onKeyPressCapture",
+    "referrerPolicy",
+    "onMouseMove",
+    "onPointerDown",
+    "onReset",
+    "onScrollCapture",
+    "onEncryptedCapture",
+    "onWaiting",
+    "placeholder",
+    "onCompositionUpdate",
+    "onTouchEndCapture",
+    "onLoadedMetadata",
+    "onCanPlay",
+    "onCopy",
+    "onTouchMoveCapture",
+    "onLoadCapture",
+    "onMouseDownCapture",
+    "pattern",
+    "onCanPlayThrough",
+    "onTransitionEnd",
+    "min",
+    "autoComplete",
+    "referrer",
+    "checked",
+    "onWheelCapture",
+    "autoFocus",
+    "alt",
+    "onTransitionEndCapture",
+    "onPause",
+    "onLoadedDataCapture",
+    "onAuxClickCapture",
+    "onDragStart",
+    "onInputCapture",
+    "onAbort",
+    "onBlurCapture",
+    "onTouchStartCapture",
+    "onCompositionStartCapture",
+    "onDrag",
+    "max",
+    "enterKeyHint",
+    "onInput",
+    "width",
+    "accept",
+    "onResetCapture",
+    "onScroll",
+    "suppressContentEditableWarning",
+    "onKeyUpCapture",
+    "onPaste",
+    "onPauseCapture",
+    "onTouchMove",
+    "onDoubleClickCapture",
+    "defaultChecked",
+    "spellCheck",
+    "onChangeCapture",
+    "onBeforeInputCapture",
+    "onInvalid",
+    "fetchPriority",
+    "onAnimationEndCapture",
+    "onSeeked",
+    "onToggle",
+    "onPlayCapture",
+    "onAnimationIteration",
+    "onEndedCapture",
+    "onPlaying",
+    "multiple",
+    "dangerouslySetInnerHTML",
+    "as",
+    "onLoadedMetadataCapture",
+    "href",
+    "draggable",
+    "lang",
+    "onAnimationEnd",
+    "translate",
+    "imageSrcSet",
+    "onRateChange",
+    "itemProp",
+    "onPointerLeave",
+    "onSelect",
+    "onMouseOut",
+    "dirname",
+    "onMouseDown",
+    "onPointerUp",
+    "style",
+    "onGotPointerCaptureCapture",
+    "onLoadStartCapture",
+    "formNoValidate",
+    "className",
+    "onClickCapture",
+    "onFocusCapture",
+    "onDragEnd",
+    "is",
+    "onPasteCapture",
+    "onVolumeChange",
+    "onDragOver",
+    "onMouseOutCapture",
+    "onCompositionStart",
+    "onDragCapture",
+    "onMouseEnter",
+    "onFocus",
+    "onLostPointerCapture",
+    "onEmptied",
+    "onMouseMoveCapture",
+    "onBlur",
+    "onContextMenuCapture",
+    "wrap",
+    "onChange",
+    "onKeyPress",
+    "onMouseUp",
+    "onSubmit",
+    "onTouchCancel",
+    "integrity",
+    "id",
+    "onDragOverCapture",
+    "minLength",
+    "onTouchEnd",
+    "onAuxClick",
+    "onLoad",
+    "content",
+    "onCanPlayThroughCapture",
+    "onAnimationStartCapture",
+    "onAnimationStart",
+    "onDragEnter",
+    "onPointerDownCapture",
+    "onEnded",
+    "onProgress",
+    "onDragEndCapture",
+    "slot",
+    "onRateChangeCapture",
+    "onMouseLeave",
+    "async",
+    "height",
+    "step",
+    "disabled",
+    "onLoadedData",
+    "src",
+    "onPointerEnter",
+    "onTouchCancelCapture",
+    "readOnly",
+    "size",
+    "suppressHydrationWarning",
+    "htmlFor",
+    "onPointerOutCapture",
+    "onCopyCapture",
+    "onDoubleClick",
+    "onCompositionEnd",
+    "onCompositionEndCapture",
+    "onSeeking",
+    "onPointerOut",
+    "onSubmitCapture",
+    "onSeekedCapture",
+    "onEncrypted",
+    "onLostPointerCaptureCapture",
+    "onToggleCapture",
+    "onPointerUpCapture",
+    "onWheel",
+    "onCut",
+    "onAbortCapture",
+    "onResizeCapture",
+    "httpEquiv",
+    "onResize",
+    "type",
+    "onVolumeChangeCapture",
+    "onSelectCapture",
+    "onDragStartCapture",
+    "imageSizes",
+    "crossOrigin",
+    "autoCapitalize",
+    "value",
+    "list",
+    "onInvalidCapture",
+    "formTarget",
+    "onAnimationIterationCapture",
+    "onStalled",
+    "onWaitingCapture",
+    "cols",
+    "onPointerMove",
+    "onDragEnterCapture",
+    "tabIndex",
+    "onPlayingCapture",
+    "rows",
+    "role",
+    "onPointerMoveCapture",
+    "onContextMenu",
+    "hidden",
+    "noModule",
+    "formMethod",
+    "sizes",
+    "onPlay",
+    "onDurationChangeCapture",
+    "onErrorCapture",
+    "onDrop",
+    "defaultValue",
+    "name",
+}
+
+REACT_PROP_SUBSTITUTIONS = {prop.lower(): prop for prop in KNOWN_REACT_PROPS} | {
+    "for": "htmlFor",
+    "class": "className",
+    "checked": "defaultChecked",
+    "accept-charset": "acceptCharset",
+    "http-equiv": "httpEquiv",
+}
+"""A mapping of HTML prop names to their ReactJS equivalents, where:
+Key = HTML prop name
+Value = Equivalent ReactJS prop name
+"""

--- a/src/reactpy/transforms.py
+++ b/src/reactpy/transforms.py
@@ -98,12 +98,18 @@ class RequiredTransforms:
     def infer_key_from_attributes(vdom: VdomDict) -> None:
         """Infer the ReactJS `key` by looking at any attributes that should be unique."""
         attributes = vdom.get("attributes", {})
+        if not attributes:
+            return
 
-        # Infer 'key' from 'id'
+        # Infer 'key' from 'attributes.key'
+        key = attributes.pop("key", None)
+
+        # Infer 'key' from 'attributes.id'
+        if key is None:
         key = attributes.get("id")
 
-        # Fallback: Infer 'key' from 'name'
-        if not key and vdom["tagName"] in {"input", "select", "textarea"}:
+        # Infer 'key' from 'attributes.name'
+        if key is None and vdom["tagName"] in {"input", "select", "textarea"}:
             key = attributes.get("name")
 
         if key:

--- a/src/reactpy/types.py
+++ b/src/reactpy/types.py
@@ -92,7 +92,7 @@ class LayoutType(Protocol[_Render_co, _Event_contra]):
         """Clean up the view after its final render"""
 
 
-VdomAttributes = Mapping[str, Any]
+VdomAttributes = dict[str, Any]
 """Describes the attributes of a :class:`VdomDict`"""
 
 VdomChild: TypeAlias = "ComponentType | VdomDict | str | None | Any"

--- a/src/reactpy/utils.py
+++ b/src/reactpy/utils.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Iterable
 from importlib import import_module
 from itertools import chain
-from typing import Any, Callable, Generic, TypeVar, Union, cast
+from typing import Any, Callable, Generic, TypeVar, cast
 
 from lxml import etree
 from lxml.html import fromstring, tostring

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -337,6 +337,10 @@ def example_child():
             html.div(example_parent()),
             '<div><div id="sample" style="padding:15px"><h1>Sample Application</h1></div></div>',
         ),
+        (
+            html.form({"acceptCharset": "utf-8"}),
+            '<form accept-charset="utf-8"></form>',
+        ),
     ],
 )
 def test_vdom_to_html(vdom_in, html_out):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -278,7 +278,17 @@ def example_middle():
 
 @component
 def example_child():
-    return html.h1("Sample Application")
+    return html.h1("Example")
+
+
+@component
+def example_str_return():
+    return "Example"
+
+
+@component
+def example_none_return():
+    return None
 
 
 @pytest.mark.parametrize(
@@ -341,15 +351,23 @@ def example_child():
         ),
         (
             html.div(example_parent()),
-            '<div><div id="sample" style="padding:15px"><h1>Sample Application</h1></div></div>',
+            '<div><div id="sample" style="padding:15px"><h1>Example</h1></div></div>',
         ),
         (
             example_parent(),
-            '<div id="sample" style="padding:15px"><h1>Sample Application</h1></div>',
+            '<div id="sample" style="padding:15px"><h1>Example</h1></div>',
         ),
         (
             html.form({"acceptCharset": "utf-8"}),
             '<form accept-charset="utf-8"></form>',
+        ),
+        (
+            example_str_return(),
+            "<div>Example</div>",
+        ),
+        (
+            example_none_return(),
+            "",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,6 +185,11 @@ def test_html_to_vdom(case):
                 "attributes": {"type": "text", "name": "my-input"},
             },
         },
+        # 8: Infer ReactJS `key` from the `key` attribute
+        {
+            "source": '<div key="my-key"></div>',
+            "model": {"tagName": "div", "key": "my-key"},
+        },
     ],
 )
 def test_html_to_vdom_default_transforms(case):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -153,37 +153,6 @@ def test_html_to_vdom_with_no_parent_node():
     assert utils.html_to_vdom(source) == expected
 
 
-def test_del_html_body_transform():
-    source = """
-    <!DOCTYPE html>
-    <html lang="en">
-
-    <head>
-    <title>My Title</title>
-    </head>
-
-    <body><h1>Hello World</h1></body>
-
-    </html>
-    """
-
-    expected = {
-        "tagName": "",
-        "children": [
-            {
-                "tagName": "",
-                "children": [{"tagName": "title", "children": ["My Title"]}],
-            },
-            {
-                "tagName": "",
-                "children": [{"tagName": "h1", "children": ["Hello World"]}],
-            },
-        ],
-    }
-
-    assert utils.html_to_vdom(source, utils.del_html_head_body_transform) == expected
-
-
 SOME_OBJECT = object()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,8 +88,8 @@ def test_ref_repr():
         },
     ],
 )
-def test_html_to_vdom(case):
-    assert utils.html_to_vdom(case["source"]) == case["model"]
+def test_string_to_reactpy(case):
+    assert utils.string_to_reactpy(case["source"]) == case["model"]
 
 
 @pytest.mark.parametrize(
@@ -192,18 +192,18 @@ def test_html_to_vdom(case):
         },
     ],
 )
-def test_html_to_vdom_default_transforms(case):
-    assert utils.html_to_vdom(case["source"]) == case["model"]
+def test_string_to_reactpy_default_transforms(case):
+    assert utils.string_to_reactpy(case["source"]) == case["model"]
 
 
-def test_html_to_vdom_intercept_links():
+def test_string_to_reactpy_intercept_links():
     source = '<a href="https://example.com">Hello World</a>'
     expected = {
         "tagName": "a",
         "children": ["Hello World"],
         "attributes": {"href": "https://example.com"},
     }
-    result = utils.html_to_vdom(source, intercept_links=True)
+    result = utils.string_to_reactpy(source, intercept_links=True)
 
     # Check if the result equals expected when removing `eventHandlers` from the result dict
     event_handlers = result.pop("eventHandlers", {})
@@ -213,7 +213,7 @@ def test_html_to_vdom_intercept_links():
     assert "onClick" in event_handlers
 
 
-def test_html_to_vdom_custom_transform():
+def test_string_to_reactpy_custom_transform():
     source = "<p>hello <a>world</a> and <a>universe</a>lmao</p>"
 
     def make_links_blue(node):
@@ -241,7 +241,8 @@ def test_html_to_vdom_custom_transform():
     }
 
     assert (
-        utils.html_to_vdom(source, make_links_blue, intercept_links=False) == expected
+        utils.string_to_reactpy(source, make_links_blue, intercept_links=False)
+        == expected
     )
 
 
@@ -256,10 +257,10 @@ def test_non_html_tag_behavior():
         ],
     }
 
-    assert utils.html_to_vdom(source, strict=False) == expected
+    assert utils.string_to_reactpy(source, strict=False) == expected
 
     with pytest.raises(utils.HTMLParseError):
-        utils.html_to_vdom(source, strict=True)
+        utils.string_to_reactpy(source, strict=True)
 
 
 SOME_OBJECT = object()
@@ -343,18 +344,22 @@ def example_child():
             '<div><div id="sample" style="padding:15px"><h1>Sample Application</h1></div></div>',
         ),
         (
+            example_parent(),
+            '<div id="sample" style="padding:15px"><h1>Sample Application</h1></div>',
+        ),
+        (
             html.form({"acceptCharset": "utf-8"}),
             '<form accept-charset="utf-8"></form>',
         ),
     ],
 )
-def test_vdom_to_html(vdom_in, html_out):
-    assert utils.vdom_to_html(vdom_in) == html_out
+def test_reactpy_to_string(vdom_in, html_out):
+    assert utils.reactpy_to_string(vdom_in) == html_out
 
 
-def test_vdom_to_html_error():
+def test_reactpy_to_string_error():
     with pytest.raises(TypeError, match="Expected a VDOM dict"):
-        utils.vdom_to_html({"notVdom": True})
+        utils.reactpy_to_string({"notVdom": True})
 
 
 def test_invalid_dotted_path():


### PR DESCRIPTION
## Description

This PR predominantly is to [backport](https://github.com/reactive-python/reactpy/issues/1258) the improved `vdom_to_html` transforms from `reactpy-django` into `reactpy`.

## Changelog

- Renamed `reactpy.utils.html_to_vdom` to `reactpy.utils.string_to_reactpy`.
- Renamed `reactpy.utils.vdom_to_html` to `reactpy.utils.reactpy_to_string`.
- `reactpy.utils.string_to_reactpy` has been upgraded to handle more complex scenarios without causing ReactJS rendering errors.
- `reactpy.utils.reactpy_to_string` will now retain the user's original casing for element `data-*` and `aria-*` attributes.
- Convert `pragma: no cover` comments to `nocov`

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
