### PR TITLE
v2.0.0b4

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -57,6 +57,7 @@ Unreleased
 - :pull:`1196` - Rewrite the ``event-to-object`` package to be more robust at handling properties on events.
 
 **Deprecated**
+
 -:pull:`1307` - ``reactpy.web.export`` is deprecated. Use ``reactpy.web.reactjs_component_from_*`` instead.
 -:pull:`1307` - ``reactpy.web.module_from_file`` is deprecated. Use ``reactpy.web.reactjs_component_from_file`` instead.
 -:pull:`1307` - ``reactpy.web.module_from_url`` is deprecated. Use ``reactpy.web.reactjs_component_from_url`` instead.

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -82,6 +82,8 @@ Unreleased
 - :pull:`1281` - Removed ``reactpy.vdom``. Use ``reactpy.Vdom`` instead.
 - :pull:`1281` - Removed ``reactpy.core.make_vdom_constructor``. Use ``reactpy.Vdom`` instead.
 - :pull:`1281` - Removed ``reactpy.core.custom_vdom_constructor``. Use ``reactpy.Vdom`` instead.
+- :pull:`xxxx` - Removed ``reactpy.core.serve.Stop`` exception type.
+- :pull:`xxxx` - Removed ``reactpy.Layout`` top-levle export. Use ``reactpy.core.layout.Layout`` instead.
 
 **Fixed**
 

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -82,8 +82,10 @@ Unreleased
 - :pull:`1281` - Removed ``reactpy.vdom``. Use ``reactpy.Vdom`` instead.
 - :pull:`1281` - Removed ``reactpy.core.make_vdom_constructor``. Use ``reactpy.Vdom`` instead.
 - :pull:`1281` - Removed ``reactpy.core.custom_vdom_constructor``. Use ``reactpy.Vdom`` instead.
-- :pull:`xxxx` - Removed ``reactpy.core.serve.Stop`` exception type.
-- :pull:`xxxx` - Removed ``reactpy.Layout`` top-levle export. Use ``reactpy.core.layout.Layout`` instead.
+- :pull:`1311` - Removed ``reactpy.core.serve.Stop`` type due to extended deprecation.
+- :pull:`1311` - Removed ``reactpy.Layout`` top-level export. Use ``reactpy.core.layout.Layout`` instead.
+- :pull:`1311` - Removed ``reactpy.widgets.hotswap`` due to extended deprecation.
+
 
 **Fixed**
 
@@ -291,7 +293,7 @@ v0.43.0
 
 **Deprecated**
 
-- :pull:`870` - ``ComponentType.should_render()``. This method was implemented based on
+- :pull:`870` - ``ComponentType.()``. This method was implemented based on
   reading the React/Preact source code. As it turns out though it seems like it's mostly
   a vestige from the fact that both these libraries still support class-based
   components. The ability for components to not render also caused several bugs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,10 +98,7 @@ features = ["all"]
 python = ["3.10", "3.11", "3.12", "3.13"]
 
 [tool.pytest.ini_options]
-addopts = """\
-  --strict-config
-  --strict-markers
-"""
+addopts = ["--strict-config", "--strict-markers"]
 filterwarnings = """
   ignore::DeprecationWarning:uvicorn.*
   ignore::DeprecationWarning:websockets.*

--- a/src/build_scripts/copy_dir.py
+++ b/src/build_scripts/copy_dir.py
@@ -3,7 +3,6 @@
 # dependencies = []
 # ///
 
-# ruff: noqa: INP001
 import logging
 import shutil
 import sys

--- a/src/js/packages/@reactpy/client/package.json
+++ b/src/js/packages/@reactpy/client/package.json
@@ -31,5 +31,5 @@
     "checkTypes": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/src/js/packages/@reactpy/client/src/client.ts
+++ b/src/js/packages/@reactpy/client/src/client.ts
@@ -69,7 +69,7 @@ export class ReactPyClient
       url: this.urls.componentUrl,
       readyPromise: this.ready,
       ...props.reconnectOptions,
-      onMessage: (event) => this.handleIncoming(JSON.parse(event.data)),
+      onMessage: async ({ data }) => this.handleIncoming(JSON.parse(data)),
     });
   }
 

--- a/src/js/packages/@reactpy/client/src/index.ts
+++ b/src/js/packages/@reactpy/client/src/index.ts
@@ -6,3 +6,4 @@ export * from "./vdom";
 export * from "./websocket";
 export { default as React } from "preact/compat";
 export { default as ReactDOM } from "preact/compat";
+export { default as preact } from "preact";

--- a/src/js/packages/@reactpy/client/src/index.ts
+++ b/src/js/packages/@reactpy/client/src/index.ts
@@ -6,4 +6,4 @@ export * from "./vdom";
 export * from "./websocket";
 export { default as React } from "preact/compat";
 export { default as ReactDOM } from "preact/compat";
-export { default as preact } from "preact";
+export * as preact from "preact";

--- a/src/js/packages/@reactpy/client/src/vdom.tsx
+++ b/src/js/packages/@reactpy/client/src/vdom.tsx
@@ -1,5 +1,5 @@
 import type { ReactPyClientInterface } from "./types";
-import serializeEvent from "event-to-object";
+import eventToObject from "event-to-object";
 import type {
   ReactPyVdom,
   ReactPyVdomImportSource,
@@ -212,7 +212,13 @@ function createEventHandler(
       if (stopPropagation) {
         event.stopPropagation();
       }
-      return serializeEvent(event);
+
+      // Convert JavaScript objects to plain JSON, if needed
+      if (typeof event === "object") {
+        return eventToObject(event);
+      } else {
+        return event;
+      }
     });
     client.sendMessage({ type: "layout-event", data, target });
   };

--- a/src/js/packages/event-to-object/package.json
+++ b/src/js/packages/event-to-object/package.json
@@ -31,5 +31,5 @@
     "checkTypes": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/src/js/packages/event-to-object/src/index.ts
+++ b/src/js/packages/event-to-object/src/index.ts
@@ -7,10 +7,18 @@ export default function convert(
   classObject: { [key: string]: any },
   maxDepth: number = 10,
 ): object {
-  const visited = new WeakSet<any>();
-  visited.add(classObject);
+  // Immediately return `classObject` if given an unexpected (non-object) input
+  if (!classObject || typeof classObject !== "object") {
+    console.warn(
+      "eventToObject: Expected an object input, received:",
+      classObject,
+    );
+    return classObject;
+  }
 
   // Begin conversion
+  const visited = new WeakSet<any>();
+  visited.add(classObject);
   const convertedObj: { [key: string]: any } = {};
   for (const key in classObject) {
     // Skip keys that cannot be converted

--- a/src/js/packages/event-to-object/tests/event-to-object.test.ts
+++ b/src/js/packages/event-to-object/tests/event-to-object.test.ts
@@ -670,3 +670,10 @@ test("handles recursive HTML node structures", () => {
     expect(converted.children[0].parentNode).toBeUndefined();
   }
 });
+
+test("pass-through on unexpected non-object inputs", () => {
+  expect(convert(null as any)).toEqual(null);
+  expect(convert(undefined as any)).toEqual(undefined);
+  expect(convert(42 as any)).toEqual(42);
+  expect(convert("test" as any)).toEqual("test");
+});

--- a/src/reactpy/__init__.py
+++ b/src/reactpy/__init__.py
@@ -2,7 +2,7 @@ from reactpy import config, logging, types, web, widgets
 from reactpy._html import html
 from reactpy.core import hooks
 from reactpy.core.component import component
-from reactpy.core.events import Event, event
+from reactpy.core.events import event
 from reactpy.core.hooks import (
     create_context,
     use_async_effect,
@@ -18,7 +18,6 @@ from reactpy.core.hooks import (
     use_scope,
     use_state,
 )
-from reactpy.core.layout import Layout
 from reactpy.core.vdom import Vdom
 from reactpy.pyscript.components import pyscript_component
 from reactpy.utils import Ref, reactpy_to_string, string_to_reactpy
@@ -27,8 +26,6 @@ __author__ = "The Reactive Python Team"
 __version__ = "2.0.0b4"
 
 __all__ = [
-    "Event",
-    "Layout",
     "Ref",
     "Vdom",
     "component",

--- a/src/reactpy/__init__.py
+++ b/src/reactpy/__init__.py
@@ -24,7 +24,7 @@ from reactpy.pyscript.components import pyscript_component
 from reactpy.utils import Ref, reactpy_to_string, string_to_reactpy
 
 __author__ = "The Reactive Python Team"
-__version__ = "2.0.0b3"
+__version__ = "2.0.0b4"
 
 __all__ = [
     "Event",

--- a/src/reactpy/core/events.py
+++ b/src/reactpy/core/events.py
@@ -73,18 +73,6 @@ def event(
     return setup(function) if function is not None else setup
 
 
-class Event(dict):
-    def __getattr__(self, name: str) -> Any:
-        value = self.get(name)
-        return Event(value) if isinstance(value, dict) else value
-
-    def preventDefault(self) -> None:
-        """Prevent the default action of the event."""
-
-    def stopPropagation(self) -> None:
-        """Stop the event from propagating."""
-
-
 class EventHandler:
     """Turn a function or coroutine into an event handler
 

--- a/src/reactpy/core/hooks.py
+++ b/src/reactpy/core/hooks.py
@@ -146,6 +146,12 @@ def use_effect(
     Returns:
         If not function is provided, a decorator. Otherwise ``None``.
     """
+    if asyncio.iscoroutinefunction(function):
+        raise TypeError(
+            "`use_effect` does not support async functions. "
+            "Use `use_async_effect` instead."
+        )
+
     hook = HOOK_STACK.current_hook()
     dependencies = _try_to_infer_closure_values(function, dependencies)
     memoize = use_memo(dependencies=dependencies)

--- a/src/reactpy/core/layout.py
+++ b/src/reactpy/core/layout.py
@@ -36,11 +36,11 @@ from reactpy.config import (
     REACTPY_DEBUG,
 )
 from reactpy.core._life_cycle_hook import LifeCycleHook
-from reactpy.core.events import Event
 from reactpy.core.vdom import validate_vdom_json
 from reactpy.types import (
     ComponentType,
     Context,
+    Event,
     EventHandlerDict,
     Key,
     LayoutEventMessage,

--- a/src/reactpy/core/serve.py
+++ b/src/reactpy/core/serve.py
@@ -25,16 +25,6 @@ The event will then trigger an :class:`reactpy.core.proto.EventHandlerType` in a
 """
 
 
-class Stop(BaseException):
-    """Deprecated
-
-    Stop serving changes and events
-
-    Raising this error will tell dispatchers to gracefully exit. Typically this is
-    called by code running inside a layout to tell it to stop rendering.
-    """
-
-
 async def serve_layout(
     layout: LayoutType[
         LayoutUpdateMessage | dict[str, Any], LayoutEventMessage | dict[str, Any]
@@ -44,17 +34,9 @@ async def serve_layout(
 ) -> None:
     """Run a dispatch loop for a single view instance"""
     async with layout:
-        try:
-            async with create_task_group() as task_group:
-                task_group.start_soon(_single_outgoing_loop, layout, send)
-                task_group.start_soon(_single_incoming_loop, task_group, layout, recv)
-        except Stop:  # nocov
-            warn(
-                "The Stop exception is deprecated and will be removed in a future version",
-                UserWarning,
-                stacklevel=1,
-            )
-            logger.info(f"Stopped serving {layout}")
+        async with create_task_group() as task_group:
+            task_group.start_soon(_single_outgoing_loop, layout, send)
+            task_group.start_soon(_single_incoming_loop, task_group, layout, recv)
 
 
 async def _single_outgoing_loop(

--- a/src/reactpy/core/serve.py
+++ b/src/reactpy/core/serve.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Awaitable
 from logging import getLogger
 from typing import Any, Callable
-from warnings import warn
 
 from anyio import create_task_group
 from anyio.abc import TaskGroup

--- a/src/reactpy/pyscript/utils.py
+++ b/src/reactpy/pyscript/utils.py
@@ -13,8 +13,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-import jsonpointer
-
 import reactpy
 from reactpy.config import REACTPY_DEBUG, REACTPY_PATH_PREFIX, REACTPY_WEB_MODULES_DIR
 from reactpy.types import VdomDict
@@ -116,11 +114,7 @@ def extend_pyscript_config(
 
     # Extends ReactPy's default PyScript config with user provided values.
     pyscript_config: dict[str, Any] = {
-        "packages": [
-            reactpy_version_string(),
-            f"jsonpointer=={jsonpointer.__version__}",
-            "ssl",
-        ],
+        "packages": [reactpy_version_string(), "jsonpointer==3.*", "ssl"],
         "js_modules": {
             "main": {
                 f"{REACTPY_PATH_PREFIX.current}static/morphdom/morphdom-esm.js": "morphdom"

--- a/src/reactpy/types.py
+++ b/src/reactpy/types.py
@@ -1071,3 +1071,19 @@ class CustomVdomConstructor(Protocol):
 class EllipsisRepr:
     def __repr__(self) -> str:
         return "..."
+
+
+class Event(dict):
+    """
+    A light `dict` wrapper for event data passed to event handler functions.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        value = self.get(name)
+        return Event(value) if isinstance(value, dict) else value
+
+    def preventDefault(self) -> None:
+        """Prevent the default action of the event."""
+
+    def stopPropagation(self) -> None:
+        """Stop the event from propagating."""

--- a/src/reactpy/web/module.py
+++ b/src/reactpy/web/module.py
@@ -33,6 +33,30 @@ _FILE_WEB_MODULE_CACHE: dict[str, WebModule] = {}
 _STRING_WEB_MODULE_CACHE: dict[str, WebModule] = {}
 
 
+@overload
+def reactjs_component_from_url(
+    url: str,
+    import_names: str,
+    fallback: Any | None = ...,
+    resolve_imports: bool | None = ...,
+    resolve_imports_depth: int = ...,
+    unmount_before_update: bool = ...,
+    allow_children: bool = ...,
+) -> VdomConstructor: ...
+
+
+@overload
+def reactjs_component_from_url(
+    url: str,
+    import_names: list[str] | tuple[str, ...],
+    fallback: Any | None = ...,
+    resolve_imports: bool | None = ...,
+    resolve_imports_depth: int = ...,
+    unmount_before_update: bool = ...,
+    allow_children: bool = ...,
+) -> list[VdomConstructor]: ...
+
+
 def reactjs_component_from_url(
     url: str,
     import_names: str | list[str] | tuple[str, ...],
@@ -78,6 +102,34 @@ def reactjs_component_from_url(
         )
         _URL_WEB_MODULE_CACHE[key] = module
     return _vdom_from_web_module(module, import_names, fallback, allow_children)
+
+
+@overload
+def reactjs_component_from_file(
+    name: str,
+    file: str | Path,
+    import_names: str,
+    fallback: Any | None = ...,
+    resolve_imports: bool | None = ...,
+    resolve_imports_depth: int = ...,
+    unmount_before_update: bool = ...,
+    symlink: bool = ...,
+    allow_children: bool = ...,
+) -> VdomConstructor: ...
+
+
+@overload
+def reactjs_component_from_file(
+    name: str,
+    file: str | Path,
+    import_names: list[str] | tuple[str, ...],
+    fallback: Any | None = ...,
+    resolve_imports: bool | None = ...,
+    resolve_imports_depth: int = ...,
+    unmount_before_update: bool = ...,
+    symlink: bool = ...,
+    allow_children: bool = ...,
+) -> list[VdomConstructor]: ...
 
 
 def reactjs_component_from_file(
@@ -133,6 +185,32 @@ def reactjs_component_from_file(
         )
         _FILE_WEB_MODULE_CACHE[key] = module
     return _vdom_from_web_module(module, import_names, fallback, allow_children)
+
+
+@overload
+def reactjs_component_from_string(
+    name: str,
+    content: str,
+    import_names: str,
+    fallback: Any | None = ...,
+    resolve_imports: bool | None = ...,
+    resolve_imports_depth: int = ...,
+    unmount_before_update: bool = ...,
+    allow_children: bool = ...,
+) -> VdomConstructor: ...
+
+
+@overload
+def reactjs_component_from_string(
+    name: str,
+    content: str,
+    import_names: list[str] | tuple[str, ...],
+    fallback: Any | None = ...,
+    resolve_imports: bool | None = ...,
+    resolve_imports_depth: int = ...,
+    unmount_before_update: bool = ...,
+    allow_children: bool = ...,
+) -> list[VdomConstructor]: ...
 
 
 def reactjs_component_from_string(

--- a/src/reactpy/widgets.py
+++ b/src/reactpy/widgets.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from base64 import b64encode
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar
+from typing import Any, Callable, Protocol, TypeVar
 
 import reactpy
 from reactpy._html import html
-from reactpy._warnings import warn
-from reactpy.types import ComponentConstructor, VdomAttributes, VdomDict
+from reactpy.types import VdomAttributes, VdomDict
 
 
 def image(
@@ -22,11 +21,7 @@ def image(
     if format == "svg":
         format = "svg+xml"  # noqa: A001
 
-    if isinstance(value, str):
-        bytes_value = value.encode()
-    else:
-        bytes_value = value
-
+    bytes_value = value.encode() if isinstance(value, str) else value
     base64_value = b64encode(bytes_value).decode()
     src = f"data:image/{format};base64,{base64_value}"
 
@@ -83,20 +78,3 @@ _CastTo_co = TypeVar("_CastTo_co", covariant=True)
 
 class _CastFunc(Protocol[_CastTo_co]):
     def __call__(self, value: str) -> _CastTo_co: ...
-
-
-if TYPE_CHECKING:
-    from reactpy.testing.backend import _MountFunc
-
-
-def hotswap(
-    update_on_change: bool = False,
-) -> tuple[_MountFunc, ComponentConstructor]:  # nocov
-    warn(
-        "The 'hotswap' function is deprecated and will be removed in a future release",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    from reactpy.testing.backend import _hotswap
-
-    return _hotswap(update_on_change)

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -3,7 +3,6 @@ import pytest
 import reactpy
 from reactpy import component, html
 from reactpy.core.events import (
-    Event,
     EventHandler,
     merge_event_handler_funcs,
     merge_event_handlers,
@@ -11,6 +10,7 @@ from reactpy.core.events import (
 )
 from reactpy.core.layout import Layout
 from reactpy.testing import DisplayFixture, poll
+from reactpy.types import Event
 from tests.tooling.common import DEFAULT_TYPE_DELAY
 
 
@@ -381,7 +381,7 @@ async def test_vdom_has_prevent_default():
 
 
 def test_event_export():
-    from reactpy import Event
+    from reactpy.types import Event
 
     assert Event is not None
 

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -23,7 +23,7 @@ async def test_must_be_rendering_in_layout_to_use_hooks():
     with pytest.raises(RuntimeError, match="No life cycle hook is active"):
         await SimpleComponentWithHook().render()
 
-    async with reactpy.Layout(SimpleComponentWithHook()) as layout:
+    async with Layout(SimpleComponentWithHook()) as layout:
         await layout.render()
 
 
@@ -41,7 +41,7 @@ async def test_simple_stateful_component():
 
     sse = SimpleStatefulComponent()
 
-    async with reactpy.Layout(sse) as layout:
+    async with Layout(sse) as layout:
         update_1 = await layout.render()
         assert update_1 == update_message(
             path="",
@@ -84,7 +84,7 @@ async def test_set_state_callback_identity_is_preserved():
 
     sse = SimpleStatefulComponent()
 
-    async with reactpy.Layout(sse) as layout:
+    async with Layout(sse) as layout:
         await layout.render()
         await layout.render()
         await layout.render()
@@ -117,7 +117,7 @@ async def test_use_state_with_constructor():
         state, set_inner_state.current = reactpy.use_state(make_default)
         return reactpy.html.div(state)
 
-    async with reactpy.Layout(Outer()) as layout:
+    async with Layout(Outer()) as layout:
         await layout.render()
 
         assert constructor_call_count.current == 1
@@ -150,7 +150,7 @@ async def test_set_state_with_reducer_instead_of_value():
         count.current, set_count.current = reactpy.hooks.use_state(0)
         return reactpy.html.div(count.current)
 
-    async with reactpy.Layout(Counter()) as layout:
+    async with Layout(Counter()) as layout:
         await layout.render()
 
         for i in range(4):
@@ -319,7 +319,7 @@ async def test_use_effect_callback_occurs_after_full_render_is_complete():
         effect_triggers_after_final_render.current = not effect_triggered.current
         return reactpy.html.div()
 
-    async with reactpy.Layout(OuterComponent()) as layout:
+    async with Layout(OuterComponent()) as layout:
         await layout.render()
 
     assert effect_triggered.current
@@ -347,7 +347,7 @@ async def test_use_effect_cleanup_occurs_before_next_effect():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithEffect()) as layout:
+    async with Layout(ComponentWithEffect()) as layout:
         await layout.render()
 
         assert not cleanup_triggered.current
@@ -386,7 +386,7 @@ async def test_use_effect_cleanup_occurs_on_will_unmount():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(OuterComponent()) as layout:
+    async with Layout(OuterComponent()) as layout:
         await layout.render()
 
         assert not cleanup_triggered.current
@@ -417,7 +417,7 @@ async def test_memoized_effect_on_recreated_if_dependencies_change():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithMemoizedEffect()) as layout:
+    async with Layout(ComponentWithMemoizedEffect()) as layout:
         await layout.render()
 
         assert effect_run_count.current == 1
@@ -460,7 +460,7 @@ async def test_memoized_effect_cleanup_only_triggered_before_new_effect():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithEffect()) as layout:
+    async with Layout(ComponentWithEffect()) as layout:
         await layout.render()
 
         assert cleanup_trigger_count.current == 0
@@ -487,7 +487,7 @@ async def test_use_async_effect():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithAsyncEffect()) as layout:
+    async with Layout(ComponentWithAsyncEffect()) as layout:
         await layout.render()
         await asyncio.wait_for(effect_ran.wait(), 1)
 
@@ -508,7 +508,7 @@ async def test_use_async_effect_cleanup():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithAsyncEffect()) as layout:
+    async with Layout(ComponentWithAsyncEffect()) as layout:
         await layout.render()
 
         component_hook.latest.schedule_render()
@@ -540,7 +540,7 @@ async def test_use_async_effect_cancel(caplog):
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithLongWaitingEffect()) as layout:
+    async with Layout(ComponentWithLongWaitingEffect()) as layout:
         await layout.render()
 
         await effect_ran.wait()
@@ -568,7 +568,7 @@ async def test_error_in_effect_is_gracefully_handled(caplog):
         return reactpy.html.div()
 
     with assert_reactpy_did_log(match_message=r"Error in effect"):
-        async with reactpy.Layout(ComponentWithEffect()) as layout:
+        async with Layout(ComponentWithEffect()) as layout:
             await layout.render()  # no error
 
 
@@ -596,7 +596,7 @@ async def test_error_in_effect_pre_unmount_cleanup_is_gracefully_handled():
         match_message=r"Error in effect",
         error_type=ValueError,
     ):
-        async with reactpy.Layout(OuterComponent()) as layout:
+        async with Layout(OuterComponent()) as layout:
             await layout.render()
             set_key.current("second")
             await layout.render()  # no error
@@ -622,7 +622,7 @@ async def test_use_reducer():
         )
         return reactpy.html.div()
 
-    async with reactpy.Layout(Counter(0)) as layout:
+    async with Layout(Counter(0)) as layout:
         await layout.render()
 
         assert saved_count.current == 0
@@ -653,7 +653,7 @@ async def test_use_reducer_dispatch_callback_identity_is_preserved():
         saved_dispatchers.append(reactpy.hooks.use_reducer(reducer, 0)[1])
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithUseReduce()) as layout:
+    async with Layout(ComponentWithUseReduce()) as layout:
         for _ in range(3):
             await layout.render()
             saved_dispatchers[-1]("increment")
@@ -673,7 +673,7 @@ async def test_use_callback_identity():
         used_callbacks.append(reactpy.hooks.use_callback(lambda: None))
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithRef()) as layout:
+    async with Layout(ComponentWithRef()) as layout:
         await layout.render()
         component_hook.latest.schedule_render()
         await layout.render()
@@ -701,7 +701,7 @@ async def test_use_callback_memoization():
         used_callbacks.append(cb)
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithRef()) as layout:
+    async with Layout(ComponentWithRef()) as layout:
         await layout.render()
         set_state_hook.current(1)
         await layout.render()
@@ -731,7 +731,7 @@ async def test_use_memo():
         used_values.append(value)
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithMemo()) as layout:
+    async with Layout(ComponentWithMemo()) as layout:
         await layout.render()
         set_state_hook.current(1)
         await layout.render()
@@ -756,7 +756,7 @@ async def test_use_memo_always_runs_if_dependencies_are_none():
         used_values.append(value)
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithMemo()) as layout:
+    async with Layout(ComponentWithMemo()) as layout:
         await layout.render()
         component_hook.latest.schedule_render()
         await layout.render()
@@ -783,7 +783,7 @@ async def test_use_memo_with_stored_deps_is_empty_tuple_after_deps_are_none():
         used_values.append(value)
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithMemo()) as layout:
+    async with Layout(ComponentWithMemo()) as layout:
         await layout.render()
         component_hook.latest.schedule_render()
         deps_used_in_memo.current = None
@@ -808,7 +808,7 @@ async def test_use_memo_never_runs_if_deps_is_empty_list():
         used_values.append(value)
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithMemo()) as layout:
+    async with Layout(ComponentWithMemo()) as layout:
         await layout.render()
         component_hook.latest.schedule_render()
         await layout.render()
@@ -828,7 +828,7 @@ async def test_use_ref():
         used_refs.append(reactpy.hooks.use_ref(1))
         return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentWithRef()) as layout:
+    async with Layout(ComponentWithRef()) as layout:
         await layout.render()
         component_hook.latest.schedule_render()
         await layout.render()
@@ -864,7 +864,7 @@ async def test_use_effect_automatically_infers_closure_values():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(CounterWithEffect()) as layout:
+    async with Layout(CounterWithEffect()) as layout:
         await layout.render()
         await did_effect.wait()
         did_effect.clear()
@@ -892,7 +892,7 @@ async def test_use_memo_automatically_infers_closure_values():
 
         return reactpy.html.div()
 
-    async with reactpy.Layout(CounterWithEffect()) as layout:
+    async with Layout(CounterWithEffect()) as layout:
         await layout.render()
         await did_memo.wait()
         did_memo.clear()
@@ -917,7 +917,7 @@ async def test_use_context_default_value():
         value.current = reactpy.use_context(Context)
         return html.div()
 
-    async with reactpy.Layout(ComponentProvidesContext()) as layout:
+    async with Layout(ComponentProvidesContext()) as layout:
         await layout.render()
         assert value.current == "something"
 
@@ -926,7 +926,7 @@ async def test_use_context_default_value():
         value.current = reactpy.use_context(Context)
         return html.div()
 
-    async with reactpy.Layout(ComponentUsesContext2()) as layout:
+    async with Layout(ComponentUsesContext2()) as layout:
         await layout.render()
         assert value.current == "something"
 
@@ -958,7 +958,7 @@ async def test_use_context_updates_components_even_if_memoized():
         render_count.current += 1
         return html.div()
 
-    async with reactpy.Layout(ComponentProvidesContext()) as layout:
+    async with Layout(ComponentProvidesContext()) as layout:
         await layout.render()
         assert render_count.current == 1
         assert value.current == 0
@@ -1016,7 +1016,7 @@ async def test_error_in_layout_effect_cleanup_is_gracefully_handled():
         error_type=ValueError,
         match_error="The error message",
     ):
-        async with reactpy.Layout(ComponentWithEffect()) as layout:
+        async with Layout(ComponentWithEffect()) as layout:
             await layout.render()
             component_hook.latest.schedule_render()
             await layout.render()  # no error
@@ -1058,7 +1058,7 @@ async def test_use_debug_mode():
         reactpy.use_debug_value(f"message is {message!r}")
         return reactpy.html.div()
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         with assert_reactpy_did_log(r"SomeComponent\(.*?\) message is 'hello'"):
             await layout.render()
 
@@ -1085,7 +1085,7 @@ async def test_use_debug_mode_with_factory():
         reactpy.use_debug_value(lambda: f"message is {message!r}")
         return reactpy.html.div()
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         with assert_reactpy_did_log(r"SomeComponent\(.*?\) message is 'hello'"):
             await layout.render()
 
@@ -1110,7 +1110,7 @@ async def test_use_debug_mode_does_not_log_if_not_in_debug_mode():
         reactpy.use_debug_value(lambda: f"message is {message!r}")
         return reactpy.html.div()
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         with assert_reactpy_did_not_log(r"SomeComponent\(.*?\) message is 'hello'"):
             await layout.render()
 
@@ -1141,9 +1141,7 @@ async def test_conditionally_rendered_components_can_use_context():
     def SecondCondition():
         used_context_values.append(reactpy.use_context(some_context) + "-2")
 
-    async with reactpy.Layout(
-        some_context(SomeComponent(), value="the-value")
-    ) as layout:
+    async with Layout(some_context(SomeComponent(), value="the-value")) as layout:
         await layout.render()
         assert used_context_values == ["the-value-1"]
         set_state.current(False)
@@ -1217,7 +1215,7 @@ async def test_use_state_compares_with_strict_equality(get_value):
         _, set_state.current = reactpy.use_state(get_value())
         render_count.current += 1
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         await layout.render()
         assert render_count.current == 1
         set_state.current(get_value())
@@ -1238,7 +1236,7 @@ async def test_use_effect_compares_with_strict_equality(get_value):
         def incr_effect_count():
             effect_count.current += 1
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         await layout.render()
         assert effect_count.current == 1
         value.current = get_value()
@@ -1255,7 +1253,7 @@ async def test_use_state_named_tuple():
     def some_component():
         state.current = reactpy.use_state(1)
 
-    async with reactpy.Layout(some_component()) as layout:
+    async with Layout(some_component()) as layout:
         await layout.render()
         assert state.current.value == 1
         state.current.set_value(2)
@@ -1283,7 +1281,7 @@ async def test_error_in_component_effect_cleanup_is_gracefully_handled():
         error_type=ValueError,
         match_error="The error message",
     ):
-        async with reactpy.Layout(ComponentWithEffect()) as layout:
+        async with Layout(ComponentWithEffect()) as layout:
             await layout.render()
             component_hook.latest.schedule_render()
             await layout.render()  # no error
@@ -1304,7 +1302,7 @@ def test_use_effect_exception_on_async_function():
     ):
 
         async def run_test():
-            async with reactpy.Layout(ComponentWithBadEffect()) as layout:
+            async with Layout(ComponentWithBadEffect()) as layout:
                 await layout.render()
 
         asyncio.run(run_test())

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -1287,3 +1287,24 @@ async def test_error_in_component_effect_cleanup_is_gracefully_handled():
             await layout.render()
             component_hook.latest.schedule_render()
             await layout.render()  # no error
+
+
+def test_use_effect_exception_on_async_function():
+    @reactpy.component
+    def ComponentWithBadEffect():
+        @reactpy.hooks.use_effect
+        async def bad_effect():
+            pass
+
+        return reactpy.html.div()
+
+    with assert_reactpy_did_log(
+        match_error="does not support async functions",
+        error_type=TypeError,
+    ):
+
+        async def run_test():
+            async with reactpy.Layout(ComponentWithBadEffect()) as layout:
+                await layout.render()
+
+        asyncio.run(run_test())

--- a/tests/test_core/test_layout.py
+++ b/tests/test_core/test_layout.py
@@ -51,15 +51,15 @@ def test_layout_repr():
     def MyComponent(): ...
 
     my_component = MyComponent()
-    layout = reactpy.Layout(my_component)
+    layout = Layout(my_component)
     assert str(layout) == f"Layout(MyComponent({id(my_component):02x}))"
 
 
 def test_layout_expects_abstract_component():
     with pytest.raises(TypeError, match="Expected a ComponentType"):
-        reactpy.Layout(None)
+        Layout(None)
     with pytest.raises(TypeError, match="Expected a ComponentType"):
-        reactpy.Layout(reactpy.html.div())
+        Layout(reactpy.html.div())
 
 
 async def test_layout_cannot_be_used_outside_context_manager(caplog):
@@ -67,7 +67,7 @@ async def test_layout_cannot_be_used_outside_context_manager(caplog):
     def Component(): ...
 
     component = Component()
-    layout = reactpy.Layout(component)
+    layout = Layout(component)
 
     with pytest.raises(AttributeError):
         await layout.deliver(event_message("something"))
@@ -84,7 +84,7 @@ async def test_simple_layout():
         tag, set_state_hook.current = reactpy.hooks.use_state("div")
         return reactpy.Vdom(tag)()
 
-    async with reactpy.Layout(SimpleComponent()) as layout:
+    async with Layout(SimpleComponent()) as layout:
         update_1 = await layout.render()
         assert update_1 == update_message(
             path="",
@@ -131,7 +131,7 @@ async def test_nested_component_layout():
             "children": [{"tagName": "div", "children": [str(state)]}],
         }
 
-    async with reactpy.Layout(Parent()) as layout:
+    async with Layout(Parent()) as layout:
         update_1 = await layout.render()
         assert update_1 == update_message(
             path="",
@@ -174,7 +174,7 @@ async def test_layout_render_error_has_partial_update_with_error_message():
         raise ValueError(msg)
 
     with assert_reactpy_did_log(match_error="error from bad child"):
-        async with reactpy.Layout(Main()) as layout:
+        async with Layout(Main()) as layout:
             assert (await layout.render()) == update_message(
                 path="",
                 model={
@@ -225,7 +225,7 @@ async def test_layout_render_error_has_partial_update_without_error_message():
         raise ValueError(msg)
 
     with assert_reactpy_did_log(match_error="error from bad child"):
-        async with reactpy.Layout(Main()) as layout:
+        async with Layout(Main()) as layout:
             assert (await layout.render()) == update_message(
                 path="",
                 model={
@@ -263,7 +263,7 @@ async def test_render_raw_vdom_dict_with_single_component_object_as_children():
     def Child():
         return {"tagName": "div", "children": {"tagName": "h1"}}
 
-    async with reactpy.Layout(Main()) as layout:
+    async with Layout(Main()) as layout:
         assert (await layout.render()) == update_message(
             path="",
             model={
@@ -313,7 +313,7 @@ async def test_components_are_garbage_collected():
     def Inner():
         return reactpy.html.div()
 
-    async with reactpy.Layout(Outer()) as layout:
+    async with Layout(Outer()) as layout:
         await layout.render()
 
         assert len(live_components) == 2
@@ -356,7 +356,7 @@ async def test_root_component_life_cycle_hook_is_garbage_collected():
     def Root():
         return reactpy.html.div()
 
-    async with reactpy.Layout(Root()) as layout:
+    async with Layout(Root()) as layout:
         await layout.render()
 
         assert len(live_hooks) == 1
@@ -397,7 +397,7 @@ async def test_life_cycle_hooks_are_garbage_collected():
     def Inner():
         return reactpy.html.div()
 
-    async with reactpy.Layout(Outer()) as layout:
+    async with Layout(Outer()) as layout:
         await layout.render()
 
         assert len(live_hooks) == 2
@@ -434,7 +434,7 @@ async def test_double_updated_component_is_not_double_rendered():
         run_count.current += 1
         return reactpy.html.div()
 
-    async with reactpy.Layout(AnyComponent()) as layout:
+    async with Layout(AnyComponent()) as layout:
         await layout.render()
 
         assert run_count.current == 1
@@ -466,7 +466,7 @@ async def test_update_path_to_component_that_is_not_direct_child_is_correct():
     def Child():
         return reactpy.html.div()
 
-    async with reactpy.Layout(Parent()) as layout:
+    async with Layout(Parent()) as layout:
         await layout.render()
 
         hook.latest.schedule_render()
@@ -480,7 +480,7 @@ async def test_log_on_dispatch_to_missing_event_handler(caplog):
     def SomeComponent():
         return reactpy.html.div()
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         await layout.deliver(event_message("missing"))
 
     assert re.match(
@@ -522,7 +522,7 @@ async def test_model_key_preserves_callback_identity_for_common_elements(caplog)
 
         return reactpy.html.div(children)
 
-    async with reactpy.Layout(MyComponent()) as layout:
+    async with Layout(MyComponent()) as layout:
         await layout.render()
         for _i in range(3):
             event = event_message(good_handler.target)
@@ -574,7 +574,7 @@ async def test_model_key_preserves_callback_identity_for_components():
 
         return reactpy.html.button({"onClick": callback, "id": "good"}, "good")
 
-    async with reactpy.Layout(RootComponent()) as layout:
+    async with Layout(RootComponent()) as layout:
         await layout.render()
         for _ in range(3):
             event = event_message(good_handler.target)
@@ -596,7 +596,7 @@ async def test_component_can_return_another_component_directly():
     def Inner():
         return reactpy.html.div("hello")
 
-    async with reactpy.Layout(Outer()) as layout:
+    async with Layout(Outer()) as layout:
         assert (await layout.render()) == update_message(
             path="",
             model={
@@ -630,7 +630,7 @@ async def test_hooks_for_keyed_components_get_garbage_collected():
             registered_finalizers.add(finalizer_id)
         return reactpy.html.div(finalizer_id)
 
-    async with reactpy.Layout(Outer()) as layout:
+    async with Layout(Outer()) as layout:
         await layout.render()
 
         pop_item.current()
@@ -658,7 +658,7 @@ async def test_event_handler_at_component_root_is_garbage_collected():
         event_handler.current = weakref(button["eventHandlers"]["onClick"].function)
         return button
 
-    async with reactpy.Layout(HasEventHandlerAtRoot()) as layout:
+    async with Layout(HasEventHandlerAtRoot()) as layout:
         await layout.render()
 
         for _i in range(3):
@@ -680,7 +680,7 @@ async def test_event_handler_deep_in_component_layout_is_garbage_collected():
         event_handler.current = weakref(button["eventHandlers"]["onClick"].function)
         return reactpy.html.div(reactpy.html.div(button))
 
-    async with reactpy.Layout(HasNestedEventHandler()) as layout:
+    async with Layout(HasNestedEventHandler()) as layout:
         await layout.render()
 
         for _i in range(3):
@@ -705,7 +705,7 @@ async def test_duplicate_sibling_keys_causes_error(caplog):
         else:
             return reactpy.html.div()
 
-    async with reactpy.Layout(ComponentReturnsDuplicateKeys()) as layout:
+    async with Layout(ComponentReturnsDuplicateKeys()) as layout:
         with assert_reactpy_did_log(
             error_type=ValueError,
             match_error=r"Duplicate keys \['duplicate'\] at '/children/0'",
@@ -740,7 +740,7 @@ async def test_keyed_components_preserve_hook_on_parent_update():
     def Inner():
         return reactpy.html.div()
 
-    async with reactpy.Layout(Outer()) as layout:
+    async with Layout(Outer()) as layout:
         await layout.render()
         old_inner_hook = inner_hook.latest
 
@@ -762,7 +762,7 @@ async def test_log_error_on_bad_event_handler():
         return reactpy.html.button({"onClick": raise_error})
 
     with assert_reactpy_did_log(match_error="bad event handler"):
-        async with reactpy.Layout(ComponentWithBadEventHandler()) as layout:
+        async with Layout(ComponentWithBadEventHandler()) as layout:
             await layout.render()
             event = event_message(bad_handler.target)
             await layout.deliver(event)
@@ -786,7 +786,7 @@ async def test_schedule_render_from_unmounted_hook():
     with assert_reactpy_did_log(
         r"Did not render component with model state ID .*? - component already unmounted",
     ):
-        async with reactpy.Layout(Parent()) as layout:
+        async with Layout(Parent()) as layout:
             await layout.render()
 
             old_hook = child_hook.latest
@@ -826,7 +826,7 @@ async def test_elements_and_components_with_the_same_key_can_be_interchanged():
 
         return reactpy.html.div(name)
 
-    async with reactpy.Layout(Root()) as layout:
+    async with Layout(Root()) as layout:
         await layout.render()
 
         await poll(lambda: effects).until_equals(["mount x"])
@@ -863,7 +863,7 @@ async def test_layout_does_not_copy_element_children_by_key():
             ]
         )
 
-    async with reactpy.Layout(SomeComponent()) as layout:
+    async with Layout(SomeComponent()) as layout:
         await layout.render()
 
         set_items.current([2, 3])
@@ -895,7 +895,7 @@ async def test_changing_key_of_parent_element_unmounts_children():
         state.current = reactpy.hooks.use_state(random.random)[0]
         return reactpy.html.div()
 
-    async with reactpy.Layout(Root()) as layout:
+    async with Layout(Root()) as layout:
         await layout.render()
 
         for _i in range(5):
@@ -924,7 +924,7 @@ async def test_switching_node_type_with_event_handlers():
         handler = component_static_handler.use(lambda: None)
         return html.button({"onAnotherEvent": handler})
 
-    async with reactpy.Layout(Root()) as layout:
+    async with Layout(Root()) as layout:
         await layout.render()
 
         assert element_static_handler.target in layout._event_handlers
@@ -970,7 +970,7 @@ async def test_switching_component_definition():
         use_effect(lambda: lambda: second_used_state.set_current(None))
         return html.div()
 
-    async with reactpy.Layout(Root()) as layout:
+    async with Layout(Root()) as layout:
         await layout.render()
 
         assert first_used_state.current == "first"
@@ -1026,7 +1026,7 @@ async def test_element_keys_inside_components_do_not_reset_state_of_component():
 
         return html.div({"key": child_key}, child_key)
 
-    async with reactpy.Layout(Parent()) as layout:
+    async with Layout(Parent()) as layout:
         await layout.render()
         await did_call_effect.wait()
         assert effect_calls_without_state == {"some-key", "key-0"}
@@ -1137,7 +1137,7 @@ async def test_does_render_children_after_component():
     def Child():
         return html.p("second")
 
-    async with reactpy.Layout(Parent()) as layout:
+    async with Layout(Parent()) as layout:
         update = await layout.render()
         assert update["model"] == {
             "tagName": "",
@@ -1173,7 +1173,7 @@ async def test_render_removed_context_consumer():
         nonlocal schedule_removed_child_render
         schedule_removed_child_render = use_force_render()
 
-    async with reactpy.Layout(Parent()) as layout:
+    async with Layout(Parent()) as layout:
         await layout.render()
 
         # If the context provider does not render its children then internally tracked
@@ -1226,7 +1226,7 @@ async def test_ensure_model_path_udpates():
         items = use_state(["A", "B", "C"])
         return html.fragment([Item(item, items, key=item) for item in items.value])
 
-    async with layout_runner(reactpy.Layout(App())) as runner:
+    async with layout_runner(Layout(App())) as runner:
         tree = await runner.render()
 
         # Delete item B

--- a/tests/test_core/test_serve.py
+++ b/tests/test_core/test_serve.py
@@ -135,7 +135,7 @@ async def test_dispatcher_handles_more_than_one_event_at_a_time():
 
     task = asyncio.create_task(
         serve_layout(
-            reactpy.Layout(ComponentWithTwoEventHandlers()),
+            Layout(ComponentWithTwoEventHandlers()),
             send_queue.put,
             recv_queue.get,
         )


### PR DESCRIPTION
## Description

Beta version bump. Bugfixes and cleanup.

- Improve type hints on `reactjs_component_from_*`
- Remove `jsonpointer` dependency
- `use_effect` will now generate an exception if attempting to use an async function. Use `use_async_effect` instead.
- Add warning within `event-to-object` if providing a non-object value. Non-objects will now be passed through as-is.
- Prevent `@reactpy/client` from attempting to convert non-object types.
- Remove deprecated `Stop` exception type
- Remove deprecated `hotswap` function
- Remove top-level export of `reactpy.Layout`. Use `reactpy.core.layout.Layout` instead.
- Remove top-level export of `reactpy.Event`. Use `reactpy.types.Event` instead.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
