### PR TITLE
Fix: tests fail when 'playwright install-deps' has already run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+import contextlib
 import os
 import subprocess
 
@@ -36,14 +36,10 @@ def pytest_addoption(parser: Parser) -> None:
 
 @pytest.fixture(autouse=True, scope="session")
 def install_playwright():
-    subprocess.run(["playwright", "install", "chromium"], check=True)  # noqa: S607, S603
+    subprocess.run(["playwright", "install", "chromium"], check=True)  # noqa: S607
     # Try to install system deps, but don't fail if already installed or no root access
-    try:
-        subprocess.run(["playwright", "install-deps"], check=True)  # noqa: S607, S603
-    except subprocess.CalledProcessError:
-        # Deps may already be installed (e.g., via Dockerfile) or we may not have root access
-        # The actual browser launch will fail if deps are truly missing
-        pass
+    with contextlib.suppress(subprocess.CalledProcessError):
+        subprocess.run(["playwright", "install-deps"], check=True)  # noqa: S607
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -55,7 +51,7 @@ def rebuild():
     # passed to the subprocess.
     env = os.environ.copy()
     env.pop("HATCH_ENV_ACTIVE", None)
-    subprocess.run(["hatch", "build", "-t", "wheel"], check=True, env=env)  # noqa: S607, S603
+    subprocess.run(["hatch", "build", "-t", "wheel"], check=True, env=env)  # noqa: S607
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,13 @@ def pytest_addoption(parser: Parser) -> None:
 @pytest.fixture(autouse=True, scope="session")
 def install_playwright():
     subprocess.run(["playwright", "install", "chromium"], check=True)  # noqa: S607, S603
-    subprocess.run(["playwright", "install-deps"], check=True)  # noqa: S607, S603
+    # Try to install system deps, but don't fail if already installed or no root access
+    try:
+        subprocess.run(["playwright", "install-deps"], check=True)  # noqa: S607, S603
+    except subprocess.CalledProcessError:
+        # Deps may already be installed (e.g., via Dockerfile) or we may not have root access
+        # The actual browser launch will fail if deps are truly missing
+        pass
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
## Description

Fix: tests are failing when `'playwright install-deps'` has already been done as part of the host/container provisioning.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
