### PR TITLE
Use NPM Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,6 @@ jobs:
         with:
             job-name: "Publish to NPM"
             run-cmd: "hatch run javascript:publish_client"
-        secrets:
-            node-auth-token: ${{ secrets.NODE_AUTH_TOKEN }}
 
     publish-event-to-object:
         if: startsWith(github.event.release.name, 'event-to-object ')
@@ -30,5 +28,3 @@ jobs:
         with:
             job-name: "Publish to NPM"
             run-cmd: "hatch run javascript:publish_event_to_object"
-        secrets:
-            node-auth-token: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/src/build_scripts/build_js_app.py
+++ b/src/build_scripts/build_js_app.py
@@ -14,7 +14,6 @@ build_commands = [
         "install",
         "--cwd",
         "src/js/packages/@reactpy/app",
-        *([] if dev_mode else ["--production"]),
     ],
     [
         "bun",

--- a/src/build_scripts/build_js_client.py
+++ b/src/build_scripts/build_js_client.py
@@ -14,7 +14,6 @@ build_commands = [
         "install",
         "--cwd",
         "src/js/packages/@reactpy/client",
-        *([] if dev_mode else ["--production"]),
     ],
     [
         "bun",

--- a/src/build_scripts/build_js_event_to_object.py
+++ b/src/build_scripts/build_js_event_to_object.py
@@ -14,7 +14,6 @@ build_commands = [
         "install",
         "--cwd",
         "src/js/packages/event-to-object",
-        *([] if dev_mode else ["--production"]),
     ],
     [
         "bun",

--- a/src/js/packages/@reactpy/client/src/components.tsx
+++ b/src/js/packages/@reactpy/client/src/components.tsx
@@ -1,6 +1,12 @@
 import { set as setJsonPointer } from "json-pointer";
-import type { ChangeEvent, MutableRefObject } from "preact/compat";
-import { createContext, createElement, Fragment, type JSX } from "preact";
+import type { MutableRefObject } from "preact/compat";
+import {
+  createContext,
+  createElement,
+  Fragment,
+  type JSX,
+  type TargetedEvent,
+} from "preact";
 import { useContext, useEffect, useRef, useState } from "preact/hooks";
 import type {
   ImportSourceBinding,
@@ -82,7 +88,7 @@ function UserInputElement({ model }: { model: ReactPyVdom }): JSX.Element {
 
   const givenOnChange = props.onChange;
   if (typeof givenOnChange === "function") {
-    props.onChange = (event: ChangeEvent<any>) => {
+    props.onChange = (event: TargetedEvent<any>) => {
       // immediately update the value to give the user feedback
       if (event.target) {
         setValue((event.target as HTMLInputElement).value);


### PR DESCRIPTION
## Description

NPM has deprecated "classic publishing tokens". As a result, we must switch to Trusted Publishing.

It is currently undetermined whether `Bun` can use GitHub Workflows Trusted Publishing, so a follow-up PR may be needed.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
