### PR TITLE
Support partial as EventHandlerFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Don't forget to remove deprecated code on each major release!
 - Added support for inline JavaScript as event handlers or other attributes that expect a callable via `reactpy.types.InlineJavaScript`
 - Event functions can now call `event.preventDefault()` and `event.stopPropagation()` methods directly on the event data object, rather than using the `@event` decorator.
 - Event data now supports accessing properties via dot notation (ex. `event.target.value`).
+- Added support for partial functions in EventHandler
 - Added `reactpy.types.Event` to provide type hints for the standard `data` function argument (for example `def on_click(event: Event): ...`).
 - Added `asgi` and `jinja` installation extras (for example `pip install reactpy[asgi, jinja]`).
 - Added `reactpy.executors.asgi.ReactPy` that can be used to run ReactPy in standalone mode via ASGI.

--- a/src/reactpy/core/events.py
+++ b/src/reactpy/core/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dis
 import inspect
 from collections.abc import Callable, Sequence
-from functools import lru_cache
+from functools import lru_cache, partial
 from types import CodeType
 from typing import Any, Literal, cast, overload
 
@@ -106,6 +106,9 @@ class EventHandler(BaseEventHandler):
         func_to_inspect = cast(Any, function)
         while hasattr(func_to_inspect, "__wrapped__"):
             func_to_inspect = func_to_inspect.__wrapped__
+
+        if isinstance(func_to_inspect, partial):
+            func_to_inspect = func_to_inspect.func
 
         found_prevent_default, found_stop_propagation = _inspect_event_handler_code(
             func_to_inspect.__code__

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -1,6 +1,7 @@
 import pytest
 
 import reactpy
+from functools import partial
 from reactpy import component, html
 from reactpy.core.events import (
     EventHandler,
@@ -344,6 +345,16 @@ def test_detect_both():
         event.stopPropagation()
 
     eh = EventHandler(handler)
+    assert eh.prevent_default is True
+    assert eh.stop_propagation is True
+
+
+def test_detect_both_when_handler_is_partial():
+    def handler(event: Event, *, extra_param):
+        event.preventDefault()
+        event.stopPropagation()
+
+    eh = EventHandler(partial(handler, extra_param="extra_value"))
     assert eh.prevent_default is True
     assert eh.stop_propagation is True
 


### PR DESCRIPTION
Closes https://github.com/reactive-python/reactpy/issues/1334

## Description

Fixes the logic for inspecting the event function by unwrapping the partial function before performing the inspection.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
