### PR TITLE
Add event queue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,8 @@ jobs:
         uses: ./.github/workflows/.hatch-run.yml
         with:
             job-name: "python-{0}"
-            run-cmd: "hatch test --parallel --cover"
+            # Retries needed because GitHub workers sometimes lag enough to crash parallel workers
+            run-cmd: "hatch test --parallel --cover --retries 10"
     lint-python:
         uses: ./.github/workflows/.hatch-run.yml
         with:
@@ -25,7 +26,7 @@ jobs:
         uses: ./.github/workflows/.hatch-run.yml
         with:
             job-name: "python-{0} {1}"
-            run-cmd: "hatch test --parallel"
+            run-cmd: "hatch test --parallel --retries 10"
             runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
             python-version: '["3.11", "3.12", "3.13", "3.14"]'
     test-documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Don't forget to remove deprecated code on each major release!
 - Rewrite the `event-to-object` package to be more robust at handling properties on events.
 - Custom JS components will now automatically assume you are using ReactJS in the absence of a `bind` function.
 - Refactor layout rendering logic to improve readability and maintainability.
-- `@reactpy/client` now exports `React` and `ReactDOM`.
+- The JavaScript package `@reactpy/client` now exports `React` and `ReactDOM`, which allows third-party components to re-use the same React instance as ReactPy.
 - `reactpy.html` will now automatically flatten lists recursively (ex. `reactpy.html(["child1", ["child2"]])`)
 - `reactpy.utils.reactpy_to_string` will now retain the user's original casing for `data-*` and `aria-*` attributes.
 - `reactpy.utils.string_to_reactpy` has been upgraded to handle more complex scenarios without causing ReactJS rendering errors.

--- a/src/js/packages/@reactpy/client/src/bind.tsx
+++ b/src/js/packages/@reactpy/client/src/bind.tsx
@@ -8,9 +8,8 @@ export async function infer_bind_from_environment() {
     const ReactDOM = await import("react-dom/client");
     return (node: HTMLElement) => reactjs_bind(node, React, ReactDOM);
   } catch {
-    console.error(
-      "Unknown error occurred: 'react' is missing within this ReactPy environment! \
-      Your JavaScript components may not work as expected!",
+    console.debug(
+      "ReactPy will render JavaScript components using internal bindings for 'react'.",
     );
     return (node: HTMLElement) => local_preact_bind(node);
   }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-import pytest
-
-from reactpy.testing import GITHUB_ACTIONS
-
-pytestmark = [pytest.mark.flaky(reruns=10 if GITHUB_ACTIONS else 1)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,6 @@ from reactpy.testing import (
 )
 from reactpy.testing.display import _playwright_visible
 
-from . import pytestmark  # noqa: F401
-
 REACTPY_ASYNC_RENDERING.set_current(True)
 REACTPY_DEBUG.set_current(True)
 

--- a/tests/test_asgi/test_middleware.py
+++ b/tests/test_asgi/test_middleware.py
@@ -15,8 +15,6 @@ from reactpy.config import REACTPY_PATH_PREFIX, REACTPY_TESTS_DEFAULT_TIMEOUT
 from reactpy.executors.asgi.middleware import ReactPyMiddleware
 from reactpy.testing import BackendFixture, DisplayFixture
 
-from .. import pytestmark  # noqa: F401
-
 
 @pytest.fixture(scope="module")
 async def display(browser):

--- a/tests/test_asgi/test_pyscript.py
+++ b/tests/test_asgi/test_pyscript.py
@@ -12,8 +12,6 @@ from reactpy import html
 from reactpy.executors.asgi.pyscript import ReactPyCsr
 from reactpy.testing import BackendFixture, DisplayFixture
 
-from .. import pytestmark  # noqa: F401
-
 
 @pytest.fixture(scope="module")
 async def display(browser):

--- a/tests/test_asgi/test_standalone.py
+++ b/tests/test_asgi/test_standalone.py
@@ -13,8 +13,6 @@ from reactpy.testing import BackendFixture, DisplayFixture, poll
 from reactpy.testing.common import REACTPY_TESTS_DEFAULT_TIMEOUT
 from reactpy.types import Connection, Location
 
-from .. import pytestmark  # noqa: F401
-
 
 async def test_display_simple_hello_world(display: DisplayFixture):
     @reactpy.component

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,8 +6,6 @@ from reactpy.testing import BackendFixture, DisplayFixture, poll
 from tests.tooling.common import DEFAULT_TYPE_DELAY
 from tests.tooling.hooks import use_counter
 
-from . import pytestmark  # noqa: F401
-
 JS_DIR = Path(__file__).parent / "js"
 
 

--- a/tests/test_core/test_component.py
+++ b/tests/test_core/test_component.py
@@ -1,8 +1,6 @@
 import reactpy
 from reactpy.testing import DisplayFixture
 
-from .. import pytestmark  # noqa: F401
-
 
 def test_component_repr():
     @reactpy.component

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -566,7 +566,7 @@ async def test_event_targeting_with_index_shifting(display: DisplayFixture):
 
         return html.div(
             html.button({"id": "add-btn", "onClick": add_top}, "Add Top"),
-            html.div({"id": "list"}, [Item(i) for i in items]),
+            html.div({"id": "list"}, [Item(i, key=i) for i in items]),
         )
 
     await display.show(ListContainer)

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -16,8 +16,6 @@ from reactpy.testing import DisplayFixture, poll
 from reactpy.types import Event
 from tests.tooling.common import DEFAULT_TYPE_DELAY
 
-from .. import pytestmark  # noqa: F401
-
 
 def test_event_handler_repr():
     handler = EventHandler(lambda: None)

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -13,8 +13,6 @@ from reactpy.testing.logs import assert_reactpy_did_not_log
 from reactpy.utils import Ref
 from tests.tooling.common import DEFAULT_TYPE_DELAY, update_message
 
-from .. import pytestmark  # noqa: F401
-
 
 async def test_must_be_rendering_in_layout_to_use_hooks():
     @reactpy.component

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -7,8 +7,6 @@ from reactpy.utils import Ref
 from tests.tooling.common import DEFAULT_TYPE_DELAY
 from tests.tooling.hooks import use_counter
 
-from . import pytestmark  # noqa: F401
-
 
 async def test_script_re_run_on_content_change(display: DisplayFixture):
     @component

--- a/tests/test_pyscript/test_components.py
+++ b/tests/test_pyscript/test_components.py
@@ -8,8 +8,6 @@ from reactpy.executors.asgi import ReactPy
 from reactpy.testing import BackendFixture, DisplayFixture
 from reactpy.testing.backend import root_hotswap_component
 
-from .. import pytestmark  # noqa: F401
-
 
 @pytest.fixture(scope="module")
 async def display(browser):

--- a/tests/test_reactjs/test_modules.py
+++ b/tests/test_reactjs/test_modules.py
@@ -7,8 +7,6 @@ from reactpy import html
 from reactpy.reactjs import component_from_string, import_reactjs
 from reactpy.testing import BackendFixture, DisplayFixture
 
-from .. import pytestmark  # noqa: F401
-
 JS_FIXTURES_DIR = Path(__file__).parent / "js_fixtures"
 
 

--- a/tests/test_reactjs/test_modules_from_npm.py
+++ b/tests/test_reactjs/test_modules_from_npm.py
@@ -6,8 +6,6 @@ from reactpy import html
 from reactpy.reactjs import component_from_npm, import_reactjs
 from reactpy.testing import BackendFixture, DisplayFixture
 
-from .. import pytestmark  # noqa: F401
-
 MISSING_IMPORT_MAP_MSG = "ReactPy did not detect a suitable JavaScript import map"
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,8 +1,6 @@
 from reactpy.testing import DisplayFixture
 from tests.sample import SampleApp
 
-from . import pytestmark  # noqa: F401
-
 
 async def test_sample_app(display: DisplayFixture):
     await display.show(SampleApp)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -10,8 +10,6 @@ from reactpy.testing.backend import BackendFixture, _hotswap
 from reactpy.testing.display import DisplayFixture
 from tests.sample import SampleApp
 
-from . import pytestmark  # noqa: F401
-
 
 def test_assert_reactpy_logged_does_not_suppress_errors():
     with pytest.raises(RuntimeError, match=r"expected error"):

--- a/tests/test_web/test_module.py
+++ b/tests/test_web/test_module.py
@@ -21,8 +21,6 @@ from reactpy.testing import (
 )
 from reactpy.types import InlineJavaScript
 
-from .. import pytestmark  # noqa: F401
-
 JS_FIXTURES_DIR = Path(__file__).parent / "js_fixtures"
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -5,8 +5,6 @@ import reactpy
 from reactpy.testing import DisplayFixture, poll
 from tests.tooling.common import DEFAULT_TYPE_DELAY
 
-from . import pytestmark  # noqa: F401
-
 HERE = Path(__file__).parent
 
 


### PR DESCRIPTION
## Description

- fix #1320
- Additionally, add a client-side event queue as well
- Fix a race condition within `use_async_effect` that could sometimes cause cleanup function to not get run
- Make tests retry 10 times when running within GitHub CI. The GitHub Actions Workers can sometimes lag so much that it can cause unpredictable results, such as stalling `--parallel` workers for so long that pytest believes they are hung so they get killed. This most frequently happens on the Windows workers.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
