### PR TITLE
Fix PyScript root component not hiding after render error

### DIFF
--- a/src/reactpy/executors/pyscript/layout_handler.py
+++ b/src/reactpy/executors/pyscript/layout_handler.py
@@ -28,6 +28,8 @@ class ReactPyLayoutHandler:
         if update["path"]:
             set_pointer(root_model, update["path"], update["model"])
         else:
+            # clear old keys first, dict.update() alone would keep stale "children" around when the new model doesn't have any
+            root_model.clear()
             root_model.update(update["model"])
 
     def render_html(self, layout, model):

--- a/tests/test_pyscript/pyscript_components/root_error.py
+++ b/tests/test_pyscript/pyscript_components/root_error.py
@@ -1,0 +1,20 @@
+from reactpy import component, hooks, html
+
+
+@component
+def root():
+    count, set_count = hooks.use_state(0)
+
+    def increment(event):
+        set_count(count + 1)
+
+    # crash on purpose after a few clicks, same as the real bug report
+    if count == 3:
+        raise ValueError("This error should hide the root component")
+
+    return html.div(
+        html.button(
+            {"onClick": increment, "id": "incr", "data-count": count}, "Increment"
+        ),
+        html.p(f"PyScript Count: {count}"),
+    )

--- a/tests/test_pyscript/test_components.py
+++ b/tests/test_pyscript/test_components.py
@@ -68,6 +68,33 @@ async def test_custom_root_name(display: DisplayFixture):
     await display.page.wait_for_selector("#incr[data-count='3']")
 
 
+async def test_root_component_error_hides_component(display: DisplayFixture):
+    """A crash in the root render should hide it, not leave stale content stuck
+    on the page."""
+
+    @reactpy.component
+    def Counter():
+        return pyscript_component(
+            Path(__file__).parent / "pyscript_components" / "root_error.py",
+            initial=html.div({"id": "loading"}, "Loading..."),
+        )
+
+    await display.show(Counter)
+
+    await display.page.wait_for_selector("#loading")
+    await display.page.wait_for_selector("#incr")
+
+    await display.page.click("#incr")
+    await display.page.wait_for_selector("#incr[data-count='1']")
+
+    await display.page.click("#incr")
+    await display.page.wait_for_selector("#incr[data-count='2']")
+
+    # this click flips count to 3 -> root component raises -> button should vanish
+    await display.page.click("#incr")
+    await display.page.wait_for_selector("#incr", state="detached")
+
+
 def test_bad_file_path():
     with pytest.raises(ValueError):
         pyscript_component(initial=html.div({"id": "loading"}, "Loading...")).render()


### PR DESCRIPTION
## Description

Fixes the issue where a PyScript root component becomes unresponsive after an exception is raised during rendering.

Previously, the root model was updated using `dict.update()`, which could leave stale keys from the previous render. This caused the old DOM to remain visible instead of hiding the failed root component. The fix clears the existing root model before applying the latest update, ensuring the rendered state accurately reflects the current layout.

I have also added a regression test to verify that when a PyScript root component raises an exception during rendering, the component is removed from the page instead of leaving stale content behind.

Closes #1276

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been developed for bug fixes or new functionality.
- [x] The changelog has been updated, if necessary.
- [x] Documentation has been updated, if necessary.
- [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>